### PR TITLE
Checksum wakeup

### DIFF
--- a/.github/workflows/java_ci_with_maven.yml
+++ b/.github/workflows/java_ci_with_maven.yml
@@ -11,10 +11,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up AdoptOpenJDK 15
-      uses: joschi/setup-jdk@v2
+      uses: AdoptOpenJDK/install-jdk@v1
       with:
-        java-version: '15' # The AdoptOpenJDK version to make available on the path.
-        architecture: 'x64' # defaults to 'x64'
+        version: '15'
+        architecture: x64
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/java_ci_with_maven.yml
+++ b/.github/workflows/java_ci_with_maven.yml
@@ -10,10 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 14
-      uses: actions/setup-java@v1
+    - name: Set up AdoptOpenJDK 15
+      uses: joschi/setup-jdk@v2
       with:
-        java-version: '14.x.x'
+        java-version: '15' # The AdoptOpenJDK version to make available on the path.
+        architecture: 'x64' # defaults to 'x64'
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
           echo ${{ env.RELEASE_VERSION }}
         shell: bash
       - name: Set up AdoptOpenJDK 15
-        uses: joschi/setup-jdk@v2
+        uses: AdoptOpenJDK/install-jdk@v1
         with:
-          java-version: '15' # The AdoptOpenJDK version to make available on the path.
-          architecture: 'x64' # defaults to 'x64'
+          version: '15'
+          architecture: x64
       - name: Install submodules
         run: |
           git submodule update --init
@@ -96,10 +96,10 @@ jobs:
           echo $RELEASE_VERSION
           echo ${{ env.RELEASE_VERSION }}
       - name: Set up AdoptOpenJDK 15
-        uses: joschi/setup-jdk@v2
+        uses: AdoptOpenJDK/install-jdk@v1
         with:
-          java-version: '15' # The AdoptOpenJDK version to make available on the path.
-          architecture: 'x64' # defaults to 'x64'
+          version: '15'
+          architecture: x64
       - name: Publish package
         run: mvn -B package
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,11 @@ jobs:
           echo $RELEASE_VERSION
           echo ${{ env.RELEASE_VERSION }}
         shell: bash
-      - name: Set up OpenJDK 14
-        uses: actions/setup-java@v1
+      - name: Set up AdoptOpenJDK 15
+        uses: joschi/setup-jdk@v2
         with:
-          java-version: '14.x.x'
+          java-version: '15' # The AdoptOpenJDK version to make available on the path.
+          architecture: 'x64' # defaults to 'x64'
       - name: Install submodules
         run: |
           git submodule update --init
@@ -94,10 +95,10 @@ jobs:
         run: |
           echo $RELEASE_VERSION
           echo ${{ env.RELEASE_VERSION }}
-      - name: Set up AdoptOpenJDK 14
+      - name: Set up AdoptOpenJDK 15
         uses: joschi/setup-jdk@v2
         with:
-          java-version: '14' # The AdoptOpenJDK version to make available on the path. OpenJDK have issues on JPackage, waiting for official GitHub action.
+          java-version: '15' # The AdoptOpenJDK version to make available on the path.
           architecture: 'x64' # defaults to 'x64'
       - name: Publish package
         run: mvn -B package

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <!-- Project Version should be upgraded in Constants.java -->
-        <project.version>1.4.0</project.version>
+        <project.version>1.4.2</project.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>14</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <project.version>1.4.2</project.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>14</java.version>
-        <java.fx.version>14</java.fx.version>
+        <java.version>15</java.version>
+        <java.fx.version>15</java.fx.version>
         <javafx.maven.plugin.version>0.0.4</javafx.maven.plugin.version>
         <nrjavaserial.version>5.2.1</nrjavaserial.version>
         <jackson.version>2.11.1</jackson.version>

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -279,8 +279,10 @@ public class FireflyLuciferin extends Application {
             if (FPS_PRODUCER_COUNTER > 0 || FPS_CONSUMER_COUNTER > 0) {
                 FPS_PRODUCER = FPS_PRODUCER_COUNTER / 5;
                 FPS_CONSUMER = FPS_CONSUMER_COUNTER / 5;
-                //logger.debug(" --* Producing @ " + FPS_PRODUCER + " FPS *-- "
-                //    + " --* Consuming @ " + FPS_CONSUMER + " FPS *-- ");
+                if (config.isExtendedLog()) {
+                    logger.debug(" --* Producing @ " + FPS_PRODUCER + " FPS *-- "
+                            + " --* Consuming @ " + FPS_CONSUMER + " FPS *-- ");
+                }
                 FPS_CONSUMER_COUNTER = FPS_PRODUCER_COUNTER = 0;
             } else {
                 FPS_PRODUCER = FPS_CONSUMER = 0;

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -399,19 +399,21 @@ public class FireflyLuciferin extends Application {
 
         int i = 0, j = -1;
 
-        byte[] ledsArray = new byte[(ledNumber * 3) + 7];
+        byte[] ledsArray = new byte[(ledNumber * 3) + 8];
 
         // Adalight checksum
         int ledsCountHi = ((ledNumber - 1) >> 8) & 0xff;
         int ledsCountLo = (ledNumber - 1) & 0xff;
+        int brightnessToSend = (brightness) & 0xff;
 
-        ledsArray[++j] = (byte) ('A');
-        ledsArray[++j] = (byte) ('d');
-        ledsArray[++j] = (byte) ('a');
+        ledsArray[++j] = (byte) ('D');
+        ledsArray[++j] = (byte) ('P');
+        ledsArray[++j] = (byte) ('s');
+        ledsArray[++j] = (byte) ('o');
         ledsArray[++j] = (byte) (ledsCountHi);
         ledsArray[++j] = (byte) (ledsCountLo);
-        ledsArray[++j] = (byte) ((ledsCountHi ^ ledsCountLo ^ 0x55));
-        ledsArray[++j] = (byte) (brightness);
+        ledsArray[++j] = (byte) (brightnessToSend);
+        ledsArray[++j] = (byte) ((ledsCountHi ^ ledsCountLo ^ brightnessToSend ^ 0x55));
 
         if (leds.length == 1) {
             colorInUse = leds[0];

--- a/src/main/java/org/dpsoftware/config/Configuration.java
+++ b/src/main/java/org/dpsoftware/config/Configuration.java
@@ -111,6 +111,7 @@ public class Configuration {
 
     // LED Matrix Map
     private Map<String, LinkedHashMap<Integer, LEDCoordinate>> ledMatrix;
+    private boolean extendedLog = false;
 
     /**
      * Constructor

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -23,7 +23,7 @@ package org.dpsoftware.config;
 
 public class Constants {
 
-	public static final String FIREFLY_LUCIFERIN_VERSION = "1.4.0";
+	public static final String FIREFLY_LUCIFERIN_VERSION = "1.4.2";
 
 	// Misc
 	public static final String FIREFLY_LUCIFERIN = "Firefly Luciferin";
@@ -139,8 +139,10 @@ public class Constants {
 	public static final String SETTINGS = "Settings";
 	public static final String EXIT = "Exit";
 	public static final String CLICK_OK_DOWNLOAD = "Click Ok to download and install the new version.";
+	public static final String CLICK_OK_DOWNLOAD_LIGHT = "Click Ok to download and install the new version. Glow Worm Luciferin LIGHT firmware must be updated manually, please check that you are running the latest firmware version.";
 	public static final String CLICK_OK_DOWNLOAD_LINUX = "Click Ok to download new version in your ~/Documents/FireflyLuciferin folder. ";
 	public static final String ONCE_DOWNLOAD_FINISHED = "Once the download is finished, please go to that folder and install it manually.";
+	public static final String ONCE_DOWNLOAD_FINISHED_LIGHT = "Once the download is finished, please go to that folder and install it manually. Glow Worm Luciferin LIGHT firmware must be updated manually, please check that you are running the latest firmware version.";
 	public static final String NEW_VERSION_AVAILABLE = "New version available!";
 	public static final String UPGRADE_SUCCESS = "Upgrade success";
 	public static final String DEVICEUPGRADE_SUCCESS = " has been successfully upgraded";

--- a/src/main/java/org/dpsoftware/gui/GUIManager.java
+++ b/src/main/java/org/dpsoftware/gui/GUIManager.java
@@ -31,7 +31,6 @@ import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 import org.dpsoftware.FireflyLuciferin;
 import org.dpsoftware.MQTTManager;
 import org.dpsoftware.config.Configuration;
@@ -320,7 +319,6 @@ public class GUIManager extends JFrame {
     /**
      * Stop capturing threads
      */
-    @SneakyThrows
     public void stopCapturingThreads() {
 
         if (FireflyLuciferin.RUNNING) {
@@ -331,7 +329,11 @@ public class GUIManager extends JFrame {
             }
             if (mqttManager != null) {
                 mqttManager.publishToTopic(FireflyLuciferin.config.getMqttTopic(), Constants.STATE_OFF_SOLID);
-                TimeUnit.SECONDS.sleep(4);
+                try {
+                    TimeUnit.SECONDS.sleep(4);
+                } catch (InterruptedException e) {
+                    logger.error(e.getMessage());
+                }
             }
             FireflyLuciferin.RUNNING = false;
             if ((FireflyLuciferin.config.getCaptureMethod().equals(Configuration.WindowsCaptureMethod.DDUPL.name()))
@@ -347,7 +349,6 @@ public class GUIManager extends JFrame {
     /**
      * Start capturing threads
      */
-    @SneakyThrows
     public void startCapturingThreads() {
 
         if (!FireflyLuciferin.RUNNING) {
@@ -358,7 +359,11 @@ public class GUIManager extends JFrame {
             }
             FireflyLuciferin.RUNNING = true;
             if (mqttManager != null) {
-                TimeUnit.SECONDS.sleep(4);
+                try {
+                    TimeUnit.SECONDS.sleep(4);
+                } catch (InterruptedException e) {
+                    logger.error(e.getMessage());
+                }
                 if ((FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream())) {
                     mqttManager.publishToTopic(FireflyLuciferin.config.getMqttTopic(), Constants.STATE_ON_GLOWWORM);
                 } else {

--- a/src/main/java/org/dpsoftware/gui/UpgradeManager.java
+++ b/src/main/java/org/dpsoftware/gui/UpgradeManager.java
@@ -223,9 +223,17 @@ public class UpgradeManager {
         if (FireflyLuciferin.config.isCheckForUpdates() && fireflyUpdate) {
             String upgradeContext;
             if (com.sun.jna.Platform.isWindows()) {
-                upgradeContext = Constants.CLICK_OK_DOWNLOAD;
+                if (FireflyLuciferin.config.isMqttEnable()) {
+                    upgradeContext = Constants.CLICK_OK_DOWNLOAD;
+                } else {
+                    upgradeContext = Constants.CLICK_OK_DOWNLOAD_LIGHT;
+                }
             } else {
-                upgradeContext = Constants.CLICK_OK_DOWNLOAD_LINUX + Constants.ONCE_DOWNLOAD_FINISHED;
+                if (FireflyLuciferin.config.isMqttEnable()) {
+                    upgradeContext = Constants.CLICK_OK_DOWNLOAD_LINUX + Constants.ONCE_DOWNLOAD_FINISHED;
+                } else {
+                    upgradeContext = Constants.CLICK_OK_DOWNLOAD_LINUX + Constants.ONCE_DOWNLOAD_FINISHED_LIGHT;
+                }
             }
             Optional<ButtonType> result = guiManager.showAlert(Constants.FIREFLY_LUCIFERIN, Constants.NEW_VERSION_AVAILABLE,
                     upgradeContext, Alert.AlertType.CONFIRMATION);


### PR DESCRIPTION
- At 30FPS, in 10 minutes, `Firefly Luciferin` sends 18000 messages to its companion firmware, in this interval some messages can be malformed, this creates some weird flashes to the LED strip. Added an **improved checksum to avoid errors**.
- Ambient light effect **"remember its state" when you suspend and wake up your PC**.  
- Firefly Luciferin is now built on AdoptOpenJDK 15  

NOTE: requires `Glow Worm Luciferin` firmware 4.2.3 or newer.