### PR TITLE
Frametime improvements, benchmark

### DIFF
--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -351,7 +351,6 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
                                 Constants.FRAMERATE_CONTEXT, Alert.AlertType.ERROR);
                     });
                 }
-                log.debug(String.valueOf(framerateAlert));
             }
             if (config.isMqttEnable()) {
                 mqttManager.publishToTopic(Constants.FIREFLY_LUCIFERIN_FRAMERATE, Constants.MQTT_FRAMERATE

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -47,6 +47,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.*;
@@ -73,6 +74,7 @@ public class FireflyLuciferin extends Application {
     public static float FPS_CONSUMER = 0;
     public static float FPS_PRODUCER = 0;
     public static float FPS_GW_CONSUMER = 0;
+    public static SimpleDateFormat formatter;
     // Serial output stream
     public static SerialPort serial;
     public static OutputStream output;
@@ -103,6 +105,7 @@ public class FireflyLuciferin extends Application {
      */
     public FireflyLuciferin() {
 
+        formatter = new SimpleDateFormat(Constants.DATE_FORMAT);
         getCIComputedVersion();
         String ledMatrixInUse = "";
         try {
@@ -359,7 +362,7 @@ public class FireflyLuciferin extends Application {
                     serial = serialPortId.open(this.getClass().getName(), config.getTimeout());
                     serial.setSerialPortParams(config.getDataRate(), SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
                     SettingsController.deviceTableData.add(new GlowWormDevice(Constants.USB_DEVICE, serialPortId.getName(),
-                            Constants.DASH, Constants.DASH, Constants.DASH, Constants.DASH));
+                            Constants.DASH, Constants.DASH, Constants.DASH, Constants.DASH, FireflyLuciferin.formatter.format(new Date())));
                 }
             } catch (PortInUseException | UnsupportedCommOperationException | NullPointerException e) {
                 communicationError = true;

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -380,8 +380,10 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
                         suggestedFramerate = 20;
                     } else if (FPS_GW_CONSUMER > (15 + Constants.BENCHMARK_ERROR_MARGIN)) {
                         suggestedFramerate = 15;
-                    } else {
+                    } else if (FPS_GW_CONSUMER > (10 + Constants.BENCHMARK_ERROR_MARGIN)) {
                         suggestedFramerate = 10;
+                    } else {
+                        suggestedFramerate = 5;
                     }
                     log.error(Constants.FRAMERATE_HEADER + ". " + Constants.FRAMERATE_CONTEXT.replace("{0}", String.valueOf(suggestedFramerate)));
                     Optional<ButtonType> result = guiManager.showAlert(Constants.FRAMERATE_TITLE, Constants.FRAMERATE_HEADER,

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -358,13 +358,14 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
     private int runBenchmark(AtomicInteger framerateAlert, AtomicBoolean notified, AtomicInteger avgFramerate) {
 
         if (!notified.get()) {
-            if ((FPS_PRODUCER > 0) && (framerateAlert.get() < 10) && (FPS_GW_CONSUMER < FPS_PRODUCER - 2)) {
+            if ((FPS_PRODUCER > 0) && (framerateAlert.get() < Constants.NUMBER_OF_BENCHMARK_ITERATION)
+                    && (FPS_GW_CONSUMER < FPS_PRODUCER - Constants.BENCHMARK_ERROR_MARGIN)) {
                 framerateAlert.getAndIncrement();
             } else {
-                avgFramerate.set((int) FPS_GW_CONSUMER);
+                avgFramerate.set(avgFramerate.get() + (int) FPS_GW_CONSUMER);
                 framerateAlert.set(0);
             }
-            if (framerateAlert.get() == 10 && !notified.get()) {
+            if (framerateAlert.get() == Constants.NUMBER_OF_BENCHMARK_ITERATION && !notified.get()) {
                 notified.set(true);
                 log.error(Constants.FRAMERATE_HEADER + ". " + Constants.FRAMERATE_CONTEXT);
                 javafx.application.Platform.runLater(() -> {
@@ -372,24 +373,25 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
                             Constants.FRAMERATE_CONTEXT, Alert.AlertType.ERROR);
                 });
                 int suggestedFramerate = 0;
-                if (avgFramerate.get() > 60) {
+                int avg = avgFramerate.get() / Constants.NUMBER_OF_BENCHMARK_ITERATION;
+                if (avg > 60) {
                     suggestedFramerate = 60;
-                } else if (avgFramerate.get() > 50) {
+                } else if (avg > 50) {
                     suggestedFramerate = 50;
-                } else if (avgFramerate.get() > 40) {
+                } else if (avg > 40) {
                     suggestedFramerate = 40;
-                } else if (avgFramerate.get() > 30) {
+                } else if (avg > 30) {
                     suggestedFramerate = 30;
-                } else if (avgFramerate.get() > 25) {
+                } else if (avg > 25) {
                     suggestedFramerate = 25;
-                } else if (avgFramerate.get() > 20) {
+                } else if (avg > 20) {
                     suggestedFramerate = 20;
-                } else if (avgFramerate.get() > 15) {
+                } else if (avg > 15) {
                     suggestedFramerate = 15;
                 } else {
                     suggestedFramerate = 10;
                 }
-                log.debug(suggestedFramerate+"");
+                log.debug("Suggested framerate=" + suggestedFramerate);
             }
         }
         return avgFramerate.get();
@@ -423,7 +425,7 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
                     serial.addEventListener(this);
                     serial.notifyOnDataAvailable(true);
                     SettingsController.deviceTableData.add(new GlowWormDevice(Constants.USB_DEVICE, serialPortId.getName(),
-                            Constants.DASH, Constants.DASH, Constants.DASH, Constants.DASH, FireflyLuciferin.formatter.format(new Date())));
+                            Constants.DASH, Constants.DASH, Constants.DASH, Constants.DASH, Constants.DASH, FireflyLuciferin.formatter.format(new Date())));
                     GUIManager guiManager = new GUIManager();
                     if (numberOfSerialDevices > 1 && config.getSerialPort().equals(Constants.SERIAL_PORT_AUTO)) {
                         communicationError = true;
@@ -468,6 +470,8 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
                                     glowWormDevice.setDeviceBoard(inputLine.replace(Constants.SERIAL_BOARD, ""));
                                 } else if (inputLine.contains(Constants.SERIAL_MAC)) {
                                     glowWormDevice.setMac(inputLine.replace(Constants.SERIAL_MAC, ""));
+                                } else if (inputLine.contains(Constants.SERIAL_GPIO)) {
+                                    glowWormDevice.setGpio(inputLine.replace(Constants.SERIAL_GPIO, ""));
                                 } else if (!config.isMqttEnable() && inputLine.contains(Constants.SERIAL_FRAMERATE)) {
                                     FPS_GW_CONSUMER = Float.parseFloat(inputLine.replace(Constants.SERIAL_FRAMERATE, ""));
                                 }

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -365,7 +365,6 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
             if (framerateAlert.get() == Constants.NUMBER_OF_BENCHMARK_ITERATION && !notified.get()) {
                 notified.set(true);
                 javafx.application.Platform.runLater(() -> {
-                    log.error(Constants.FRAMERATE_HEADER + ". " + Constants.FRAMERATE_CONTEXT);
                     int suggestedFramerate;
                     if (FPS_GW_CONSUMER > (60 + Constants.BENCHMARK_ERROR_MARGIN)) {
                         suggestedFramerate = 60;
@@ -384,9 +383,9 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
                     } else {
                         suggestedFramerate = 10;
                     }
-                    log.debug("Suggested framerate=" + suggestedFramerate);
+                    log.error(Constants.FRAMERATE_HEADER + ". " + Constants.FRAMERATE_CONTEXT.replace("{0}", String.valueOf(suggestedFramerate)));
                     Optional<ButtonType> result = guiManager.showAlert(Constants.FRAMERATE_TITLE, Constants.FRAMERATE_HEADER,
-                            Constants.FRAMERATE_CONTEXT, Alert.AlertType.CONFIRMATION);
+                            Constants.FRAMERATE_CONTEXT.replace("{0}", String.valueOf(suggestedFramerate)), Alert.AlertType.CONFIRMATION);
                     ButtonType button = result.orElse(ButtonType.OK);
                     if (button == ButtonType.OK) {
                         try {
@@ -464,6 +463,7 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
             try {
                 if (input.ready()) {
                     String inputLine = input.readLine();
+                    // log.debug(inputLine);
                     SettingsController.deviceTableData.forEach(glowWormDevice -> {
                         if (glowWormDevice.getDeviceName().equals(Constants.USB_DEVICE)) {
                             glowWormDevice.setLastSeen(FireflyLuciferin.formatter.format(new Date()));
@@ -618,7 +618,7 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
 
         int i = 0, j = -1;
 
-        byte[] ledsArray = new byte[(ledNumber * 3) + 11];
+        byte[] ledsArray = new byte[(ledNumber * 3) + 8];
 
         // DPsoftware checksum
         int ledsCountHi = ((ledNumHighLowCount) >> 8) & 0xff;
@@ -629,9 +629,6 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
         ledsArray[++j] = (byte) ('D');
         ledsArray[++j] = (byte) ('P');
         ledsArray[++j] = (byte) ('s');
-        ledsArray[++j] = (byte) ('o');
-        ledsArray[++j] = (byte) ('f');
-        ledsArray[++j] = (byte) ('t');
         ledsArray[++j] = (byte) (ledsCountHi);
         ledsArray[++j] = (byte) (ledsCountLo);
         ledsArray[++j] = (byte) (loSecondPart);

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -350,8 +350,10 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
 
         CommPortIdentifier serialPortId = null;
         if (!(config.isMqttEnable() && config.isMqttStream())) {
+            int numberOfSerialDevices = 0;
             var enumComm = CommPortIdentifier.getPortIdentifiers();
-            while (enumComm.hasMoreElements() && serialPortId == null) {
+            while (enumComm.hasMoreElements()) {
+                numberOfSerialDevices++;
                 CommPortIdentifier serialPortAvailable = (CommPortIdentifier) enumComm.nextElement();
                 if (config.getSerialPort().equals(serialPortAvailable.getName()) || config.getSerialPort().equals(Constants.SERIAL_PORT_AUTO)) {
                     serialPortId = serialPortAvailable;
@@ -368,6 +370,14 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
                     serial.notifyOnDataAvailable(true);
                     SettingsController.deviceTableData.add(new GlowWormDevice(Constants.USB_DEVICE, serialPortId.getName(),
                             Constants.DASH, Constants.DASH, Constants.DASH, Constants.DASH, FireflyLuciferin.formatter.format(new Date())));
+                    GUIManager guiManager = new GUIManager();
+                    if (numberOfSerialDevices > 1 && config.getSerialPort().equals(Constants.SERIAL_PORT_AUTO)) {
+                        communicationError = true;
+                        guiManager.showAlert(Constants.SERIAL_ERROR_TITLE,
+                                Constants.SERIAL_PORT_AMBIGUOUS,
+                                Constants.SERIAL_PORT_AMBIGUOUS_CONTEXT, Alert.AlertType.ERROR);
+                        log.error(Constants.SERIAL_ERROR_OPEN_HEADER);
+                    }
                 }
             } catch (PortInUseException | UnsupportedCommOperationException | NullPointerException | IOException | TooManyListenersException e) {
                 communicationError = true;

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -402,7 +402,7 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
                                     glowWormDevice.setDeviceBoard(inputLine.replace(Constants.SERIAL_BOARD, ""));
                                 } else if (inputLine.contains(Constants.SERIAL_MAC)) {
                                     glowWormDevice.setMac(inputLine.replace(Constants.SERIAL_MAC, ""));
-                                } else if (inputLine.contains(Constants.SERIAL_FRAMERATE)) {
+                                } else if (!config.isMqttEnable() && inputLine.contains(Constants.SERIAL_FRAMERATE)) {
                                     FPS_GW_CONSUMER = Float.parseFloat(inputLine.replace(Constants.SERIAL_FRAMERATE, ""));
                                 }
                             }

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -99,6 +99,7 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
     // MQTT
     MQTTManager mqttManager = null;
     public static String version = "";
+    public static String minimumFirmwareVersion = "";
 
     /**
      * Constructor
@@ -199,6 +200,7 @@ public class FireflyLuciferin extends Application implements SerialPortEventList
         try {
             properties.load(this.getClass().getClassLoader().getResourceAsStream("project.properties"));
             version = properties.getProperty("version");
+            minimumFirmwareVersion = properties.getProperty("minimum_firmware_version");
         } catch (IOException e) {
             log.error(e.getMessage());
         }

--- a/src/main/java/org/dpsoftware/MQTTManager.java
+++ b/src/main/java/org/dpsoftware/MQTTManager.java
@@ -183,7 +183,7 @@ public class MQTTManager implements MqttCallback {
                                         log.error(e.getMessage());
                                     }
                                 }
-                                System.exit(0);
+                                FireflyLuciferin.exit();
                             } catch (InterruptedException e) {
                                 log.error(e.getMessage());
                             }

--- a/src/main/java/org/dpsoftware/MQTTManager.java
+++ b/src/main/java/org/dpsoftware/MQTTManager.java
@@ -215,36 +215,37 @@ public class MQTTManager implements MqttCallback {
         switch (topic) {
             case Constants.DEFAULT_MQTT_STATE_TOPIC:
                 ObjectMapper mapper = new ObjectMapper();
-                JsonNode actualObj = mapper.readTree(new String(message.getPayload()));
-                if (actualObj.get(Constants.STATE) != null) {
-                    if (actualObj.get(Constants.STATE).asText().equals(Constants.OFF)) {
+                JsonNode mqttmsg = mapper.readTree(new String(message.getPayload()));
+                if (mqttmsg.get(Constants.STATE) != null) {
+                    if (mqttmsg.get(Constants.STATE).asText().equals(Constants.OFF)) {
                         FireflyLuciferin.config.setToggleLed(false);
-                    } else if (actualObj.get(Constants.STATE).asText().equals(Constants.ON) && actualObj.get(Constants.EFFECT).asText().equals(Constants.SOLID)) {
+                    } else if (mqttmsg.get(Constants.STATE).asText().equals(Constants.ON) && mqttmsg.get(Constants.EFFECT).asText().equals(Constants.SOLID)) {
                         FireflyLuciferin.config.setToggleLed(true);
-                        if (actualObj.get(Constants.COLOR) != null) {
-                            FireflyLuciferin.config.setColorChooser(actualObj.get(Constants.COLOR).get("r") + "," + actualObj.get(Constants.COLOR).get("g") + ","
-                                + actualObj.get(Constants.COLOR).get("b") + "," + actualObj.get(Constants.MQTT_BRIGHTNESS));
+                        if (mqttmsg.get(Constants.COLOR) != null) {
+                            FireflyLuciferin.config.setColorChooser(mqttmsg.get(Constants.COLOR).get("r") + "," + mqttmsg.get(Constants.COLOR).get("g") + ","
+                                + mqttmsg.get(Constants.COLOR).get("b") + "," + mqttmsg.get(Constants.MQTT_BRIGHTNESS));
                         }
                     }
-                    if (actualObj.get(Constants.MQTT_TOPIC_FRAMERATE) != null) {
-                        FireflyLuciferin.FPS_GW_CONSUMER = Float.parseFloat(actualObj.get(Constants.MQTT_TOPIC_FRAMERATE).asText());
+                    if (mqttmsg.get(Constants.MQTT_TOPIC_FRAMERATE) != null) {
+                        FireflyLuciferin.FPS_GW_CONSUMER = Float.parseFloat(mqttmsg.get(Constants.MQTT_TOPIC_FRAMERATE).asText());
                     }
                 }
                 // Skip retained message, we want fresh data here
                 if (!message.isRetained()) {
-                    if (actualObj.get(Constants.WHOAMI) != null) {
+                    if (mqttmsg.get(Constants.WHOAMI) != null) {
                         if (SettingsController.deviceTableData.isEmpty()) {
-                            addDevice(actualObj);
+                            addDevice(mqttmsg);
                         } else {
                             AtomicBoolean isDevicePresent = new AtomicBoolean(false);
                             SettingsController.deviceTableData.forEach(glowWormDevice -> {
-                                String newDeviceName = actualObj.get(Constants.WHOAMI).textValue();
+                                String newDeviceName = mqttmsg.get(Constants.WHOAMI).textValue();
                                 if (glowWormDevice.getDeviceName().equals(newDeviceName)) {
                                     isDevicePresent.set(true);
+                                    glowWormDevice.setLastSeen(FireflyLuciferin.formatter.format(new Date()));
                                 }
                             });
                             if (!isDevicePresent.get()) {
-                                addDevice(actualObj);
+                                addDevice(mqttmsg);
                             }
                         }
                     }
@@ -293,7 +294,8 @@ public class MQTTManager implements MqttCallback {
                 actualObj.get(Constants.STATE_IP).textValue(), actualObj.get(Constants.DEVICE_VER).textValue(),
                 (actualObj.get(Constants.DEVICE_BOARD) == null ? Constants.DASH : actualObj.get(Constants.DEVICE_BOARD).textValue()),
                 (actualObj.get(Constants.MAC) == null ? Constants.DASH : actualObj.get(Constants.MAC).textValue()),
-                (actualObj.get(Constants.NUMBER_OF_LEDS) == null ? Constants.DASH : actualObj.get(Constants.NUMBER_OF_LEDS).textValue())));
+                (actualObj.get(Constants.NUMBER_OF_LEDS) == null ? Constants.DASH : actualObj.get(Constants.NUMBER_OF_LEDS).textValue()),
+                (FireflyLuciferin.formatter.format(new Date()))));
 
     }
 

--- a/src/main/java/org/dpsoftware/MQTTManager.java
+++ b/src/main/java/org/dpsoftware/MQTTManager.java
@@ -294,6 +294,7 @@ public class MQTTManager implements MqttCallback {
                 actualObj.get(Constants.STATE_IP).textValue(), actualObj.get(Constants.DEVICE_VER).textValue(),
                 (actualObj.get(Constants.DEVICE_BOARD) == null ? Constants.DASH : actualObj.get(Constants.DEVICE_BOARD).textValue()),
                 (actualObj.get(Constants.MAC) == null ? Constants.DASH : actualObj.get(Constants.MAC).textValue()),
+                (actualObj.get(Constants.GPIO) == null ? Constants.DASH : actualObj.get(Constants.GPIO).textValue()),
                 (actualObj.get(Constants.NUMBER_OF_LEDS) == null ? Constants.DASH : actualObj.get(Constants.NUMBER_OF_LEDS).textValue()),
                 (FireflyLuciferin.formatter.format(new Date()))));
 

--- a/src/main/java/org/dpsoftware/config/Configuration.java
+++ b/src/main/java/org/dpsoftware/config/Configuration.java
@@ -63,7 +63,7 @@ public class Configuration {
     private String serialPort;
 
     // Arduino/Microcontroller config
-    private int dataRate = 1000000;
+    private int dataRate = 500000;
     private boolean customDataRate = false;
 
     // Default led matrix to use

--- a/src/main/java/org/dpsoftware/config/Configuration.java
+++ b/src/main/java/org/dpsoftware/config/Configuration.java
@@ -63,7 +63,7 @@ public class Configuration {
     private String serialPort;
 
     // Arduino/Microcontroller config
-    private int dataRate = 500000;
+    private int dataRate = 1000000;
 
     // Default led matrix to use
     private String defaultLedMatrix;

--- a/src/main/java/org/dpsoftware/config/Configuration.java
+++ b/src/main/java/org/dpsoftware/config/Configuration.java
@@ -64,6 +64,7 @@ public class Configuration {
 
     // Arduino/Microcontroller config
     private int dataRate = 1000000;
+    private boolean customDataRate = false;
 
     // Default led matrix to use
     private String defaultLedMatrix;

--- a/src/main/java/org/dpsoftware/config/Configuration.java
+++ b/src/main/java/org/dpsoftware/config/Configuration.java
@@ -63,7 +63,7 @@ public class Configuration {
     private String serialPort;
 
     // Arduino/Microcontroller config
-    private int dataRate = 500000;
+    private int dataRate = Constants.DEFAULT_BAUD_RATE;
     private boolean customDataRate = false;
 
     // Default led matrix to use

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -224,7 +224,7 @@ public class Constants {
 	public static final String TOOLTIP_MQTTENABLE = "FULL firmware requires MQTT";
 	public static final String TOOLTIP_EYE_CARE = "If enabled LEDs will never turn off in black scenes, a soft and gentle light is used instead.";
 	public static final String TOOLTIP_AUTOSTART = "Start capture on Firefly Luciferin startup";
-	public static final String TOOLTIP_MQTTSTREAM = "Prefer wireless stream over serial port (USB cable). This option is ignored if MQTT is disabled. Enable this option if you don't have the possibility to use a USB cable.";
+	public static final String TOOLTIP_MQTTSTREAM = "Prefer wireless stream over serial port (USB cable). Enable this option if you don't have the possibility to use a USB cable.";
 	public static final String TOOLTIP_START_WITH_SYSTEM = "Launch Firefly Luciferin when system starts";
 	public static final String TOOLTIP_CHECK_UPDATES = "Set and forget it to update Firefly Luciferin and Glow Worm Luciferin when updates are available. Automatic firmware upgrade is available on FULL version only";
 	public static final String TOOLTIP_PLAYBUTTON_NULL = "Please configure and save before capturing";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -150,7 +150,7 @@ public class Constants {
 	public static final String SAVE_AND_CLOSE = "Save and close";
 	public static final String FRAMERATE_TITLE = "Framerate error";
 	public static final String FRAMERATE_HEADER = "Firefly Luciferin is out of sync";
-	public static final String FRAMERATE_CONTEXT = "Your computer is capturing the screen too fast and Glow Worm Luciferin firmware can't keep up.\nThis can cause synchronization issues, please go to \"Settings\", \"Misc\" and lower the framerate.";
+	public static final String FRAMERATE_CONTEXT = "Your computer is capturing the screen too fast and Glow Worm Luciferin firmware can't keep up.\nThis can cause synchronization issues, do you want to lower the framerate?";
 	public static final String SERIAL_ERROR_TITLE = "Serial Port Error";
 	public static final String SERIAL_ERROR_HEADER = "No serial port available";
 	public static final String SERIAL_ERROR_OPEN_HEADER = "Can't open SERIAL PORT";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -256,7 +256,7 @@ public class Constants {
 	public static final String PATH = "path";
 	public static final String JNA_LIB_PATH = "jna.library.path";
 	public static final String SCREEN_GRABBER = "ScreenGrabber";
-	public static final String GSTREAMER_PIPELINE_WINDOWS = "d3d11desktopdupsrc";
+	public static final String GSTREAMER_PIPELINE_WINDOWS = "d3d11desktopdupsrc ! queue max-size-buffers=0";
 	public static final String GSTREAMER_PIPELINE_LINUX = "ximagesrc ! videoscale ! videoconvert";
 	public static final String GSTREAMER_PIPELINE_MAC = "avfvideosrc capture-screen=true ! videoscale ! videoconvert";
 	public static final String FRAMERATE_PLACEHOLDER = "framerate=FRAMERATE_PLACEHOLDER/1,";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -38,6 +38,7 @@ public class Constants {
 	public static final String DEFAULT_COLOR_CHOOSER = "255,255,255,255";
 	public static final String CLEAN_EXIT = "CLEAN EXIT";
 	public static final int SERIAL_CHUNK_SIZE = 250;
+	public static final String DATE_FORMAT = "EEEE, MMM dd, yyyy HH:mm:ss a";
 
 	// Upgrade
 	public static final String MINIMUM_FIRMWARE_FOR_AUTO_UPGRADE = "4.0.3";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -256,7 +256,7 @@ public class Constants {
 	public static final String PATH = "path";
 	public static final String JNA_LIB_PATH = "jna.library.path";
 	public static final String SCREEN_GRABBER = "ScreenGrabber";
-	public static final String GSTREAMER_PIPELINE_WINDOWS = "d3d11desktopdupsrc ! queue max-size-buffers=1";
+	public static final String GSTREAMER_PIPELINE_WINDOWS = "d3d11desktopdupsrc";
 	public static final String GSTREAMER_PIPELINE_LINUX = "ximagesrc ! videoscale ! videoconvert";
 	public static final String GSTREAMER_PIPELINE_MAC = "avfvideosrc capture-screen=true ! videoscale ! videoconvert";
 	public static final String FRAMERATE_PLACEHOLDER = "framerate=FRAMERATE_PLACEHOLDER/1,";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -42,6 +42,7 @@ public class Constants {
 	public static final String SETTING_LED_SERIAL = "Setting LEDs";
 
 	// Upgrade
+	public static final String LIGHT_FIRMWARE_DUMMY_VERSION = "1.0.0";
 	public static final String MINIMUM_FIRMWARE_FOR_AUTO_UPGRADE = "4.0.3";
 	public static final String GITHUB_POM_URL = "https://raw.githubusercontent.com/sblantipodi/firefly_luciferin/master/pom.xml";
 	public static final String GITHUB_GLOW_WORM_URL = "https://raw.githubusercontent.com/sblantipodi/glow_worm_luciferin/master/version";
@@ -156,10 +157,8 @@ public class Constants {
 	public static final String SETTINGS = "Settings";
 	public static final String EXIT = "Exit";
 	public static final String CLICK_OK_DOWNLOAD = "Click Ok to download and install the new version.";
-	public static final String CLICK_OK_DOWNLOAD_LIGHT = "Click Ok to download and install the new version. Glow Worm Luciferin LIGHT firmware must be updated manually, please check that you are running the latest firmware version.";
 	public static final String CLICK_OK_DOWNLOAD_LINUX = "Click Ok to download new version in your ~/Documents/FireflyLuciferin folder. ";
 	public static final String ONCE_DOWNLOAD_FINISHED = "Once the download is finished, please go to that folder and install it manually.";
-	public static final String ONCE_DOWNLOAD_FINISHED_LIGHT = "Once the download is finished, please go to that folder and install it manually. Glow Worm Luciferin LIGHT firmware must be updated manually, please check that you are running the latest firmware version.";
 	public static final String NEW_VERSION_AVAILABLE = "New version available!";
 	public static final String UPGRADE_SUCCESS = "Upgrade success";
 	public static final String DEVICEUPGRADE_SUCCESS = " has been successfully upgraded";
@@ -168,7 +167,9 @@ public class Constants {
 	public static final String MANUAL_UPGRADE = "Your device is running an old firmware that doesn't support automatic updates, please update it manually.";
 	public static final String DEVICES_UPDATED = "These devices will be updated:\n";
 	public static final String DEVICE_UPDATED = "This device will be updated:\n";
+	public static final String DEVICE_UPDATED_LIGHT = "This device needs to be updated:\n";
 	public static final String UPDATE_BACKGROUND = "update process runs in background, you'll be notified when it's finished.";
+	public static final String UPDATE_NEEDED = "please download the new Glow Worm Luciferin firmware and update it manually.";
 	public static final String STOPPING_THREADS = "Stopping Threads...";
 	public static final String CAPTURE_MODE_CHANGED = "Capture mode changed to ";
 	public static final String GITHUB_URL = "https://github.com/sblantipodi/firefly_luciferin";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -107,6 +107,7 @@ public class Constants {
 	public static final String DEFAULT_MQTT_TOPIC = "lights/glowwormluciferin/set";
 	public static final String DEFAULT_MQTT_STATE_TOPIC = "lights/glowwormluciferin";
 	public static final String UPDATE_MQTT_TOPIC = "lights/glowwormluciferin/update";
+	public static final String FPS_TOPIC = "lights/glowwormluciferin/fps";
 	public static final String UPDATE_RESULT_MQTT_TOPIC = "lights/glowwormluciferin/update/result";
 	public static final String FIREFLY_LUCIFERIN_FRAMERATE = "lights/firelyluciferin/framerate";
 	public static final String FIREFLY_LUCIFERIN_GAMMA = "lights/firelyluciferin/gamma";
@@ -136,6 +137,7 @@ public class Constants {
 	public static final String MQTT_START = "START";
 	public static final String MQTT_STOP = "STOP";
 	public static final String MQTT_TOPIC_FRAMERATE = "framerate";
+	public static final String MQTT_DEVICE_NAME = "deviceName";
 	public static final int FIRST_CHUNK = 190;
 	public static final int SECOND_CHUNK = 380;
 	public static final String LED_NUM = "\"lednum\":";
@@ -150,7 +152,7 @@ public class Constants {
 	public static final String SAVE_AND_CLOSE = "Save and close";
 	public static final String FRAMERATE_TITLE = "Framerate error";
 	public static final String FRAMERATE_HEADER = "Firefly Luciferin is out of sync";
-	public static final String FRAMERATE_CONTEXT = "Your computer is capturing the screen too fast and Glow Worm Luciferin firmware can't keep up.\nThis can cause synchronization issues, do you want to lower the framerate?";
+	public static final String FRAMERATE_CONTEXT = "Your computer is capturing the screen too fast and Glow Worm Luciferin firmware can't keep up.\nThis can cause synchronization issues, do you want to lower the framerate to {0} FPS?";
 	public static final String SERIAL_ERROR_TITLE = "Serial Port Error";
 	public static final String SERIAL_ERROR_HEADER = "No serial port available";
 	public static final String SERIAL_ERROR_OPEN_HEADER = "Can't open SERIAL PORT";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -245,8 +245,10 @@ public class Constants {
 	public static final String TOOLTIP_SHOWTESTIMAGEBUTTON = "Show a test image, first and last LEDs are shown in orange. Unsaved settings will not be displayed here.";
 
 	// Grabber
+	public static final String INTERNAL_SCALING_X = "INTERNAL_SCALING_X";
+	public static final String INTERNAL_SCALING_Y = "INTERNAL_SCALING_Y";
 	public static final String EMIT_SIGNALS = "emit-signals";
-	public static final String GSTREAMER_PIPELINE_DDUPL = "video/x-raw(memory:D3D11Memory),sync=false,";
+	public static final String GSTREAMER_PIPELINE_DDUPL = "video/x-raw(memory:D3D11Memory),width=INTERNAL_SCALING_X,height=INTERNAL_SCALING_Y,pixel-aspect-ratio=1/1,use-damage=0,sync=false,";
 	public static final String GSTREAMER_PIPELINE = "video/x-raw,pixel-aspect-ratio=1/1,framerate=30/1,use-damage=0,sync=false,";
 	public static final String BYTE_ORDER_BGR = "format=BGRx";
 	public static final String BYTE_ORDER_RGB = "format=xRGB";
@@ -256,7 +258,7 @@ public class Constants {
 	public static final String PATH = "path";
 	public static final String JNA_LIB_PATH = "jna.library.path";
 	public static final String SCREEN_GRABBER = "ScreenGrabber";
-	public static final String GSTREAMER_PIPELINE_WINDOWS = "d3d11desktopdupsrc ! queue max-size-buffers=0";
+	public static final String GSTREAMER_PIPELINE_WINDOWS = "d3d11desktopdupsrc ! videoscale ! d3d11convert";
 	public static final String GSTREAMER_PIPELINE_LINUX = "ximagesrc ! videoscale ! videoconvert";
 	public static final String GSTREAMER_PIPELINE_MAC = "avfvideosrc capture-screen=true ! videoscale ! videoconvert";
 	public static final String FRAMERATE_PLACEHOLDER = "framerate=FRAMERATE_PLACEHOLDER/1,";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -39,6 +39,7 @@ public class Constants {
 	public static final String CLEAN_EXIT = "CLEAN EXIT";
 	public static final int SERIAL_CHUNK_SIZE = 250;
 	public static final String DATE_FORMAT = "EEEE, MMM dd, yyyy HH:mm:ss a";
+	public static final String SETTING_LED_SERIAL = "Setting LEDs";
 
 	// Upgrade
 	public static final String MINIMUM_FIRMWARE_FOR_AUTO_UPGRADE = "4.0.3";
@@ -188,6 +189,12 @@ public class Constants {
 	public static final String ESP32 = "ESP32";
 	public static final String DASH = "-";
 	public static final String UPDATE_FILENAME = "GlowWormLuciferinFULL_board_firmware.bin";
+	public static final String SERIAL_VERSION = "ver:";
+	public static final String SERIAL_LED_NUM = "lednum:";
+	public static final String SERIAL_BOARD = "board:";
+	public static final String SERIAL_FRAMERATE = "framerate:";
+	public static final String SERIAL_MAC = "MAC:";
+
 
 	// Tooltips
 	public static final String TOOLTIP_TOPLED = "# of LEDs in the top row";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -41,6 +41,8 @@ public class Constants {
 	public static final int SERIAL_CHUNK_SIZE = 250;
 	public static final String DATE_FORMAT = "EEEE, MMM dd, yyyy HH:mm:ss a";
 	public static final String SETTING_LED_SERIAL = "Setting LEDs";
+	public static final int NUMBER_OF_BENCHMARK_ITERATION = 10;
+	public static final int BENCHMARK_ERROR_MARGIN = 2;
 
 	// Upgrade
 	public static final String LIGHT_FIRMWARE_DUMMY_VERSION = "1.0.0";
@@ -114,6 +116,7 @@ public class Constants {
 	public static final String DEVICE_BOARD = "board";
 	public static final String NUMBER_OF_LEDS = "lednum";
 	public static final String MAC = "MAC";
+	public static final String GPIO = "gpio";
 	public static final String STATE = "state";
 	public static final String ON = "ON";
 	public static final String OFF = "OFF";
@@ -197,6 +200,7 @@ public class Constants {
 	public static final String SERIAL_BOARD = "board:";
 	public static final String SERIAL_FRAMERATE = "framerate:";
 	public static final String SERIAL_MAC = "MAC:";
+	public static final String SERIAL_GPIO = "gpio:";
 
 
 	// Tooltips

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -144,6 +144,9 @@ public class Constants {
 	// GUI
 	public static final String SAVE = "Save";
 	public static final String SAVE_AND_CLOSE = "Save and close";
+	public static final String FRAMERATE_TITLE = "Framerate error";
+	public static final String FRAMERATE_HEADER = "Luciferin is out of sync";
+	public static final String FRAMERATE_CONTEXT = "Your computer is too fast and Glow Worm Luciferin firmware can't keep up. This can cause synchronization issues, please go to \"Settings\", \"Misc\" and lower the framerate.";
 	public static final String SERIAL_ERROR_TITLE = "Serial Port Error";
 	public static final String SERIAL_ERROR_HEADER = "No serial port available";
 	public static final String SERIAL_ERROR_OPEN_HEADER = "Can't open SERIAL PORT";
@@ -180,10 +183,6 @@ public class Constants {
 	public static final String SERIAL_PORT_TTY = "/dev/ttyUSB";
 	public static final String CLOCKWISE = "Clockwise";
 	public static final String ANTICLOCKWISE = "Anticlockwise";
-	public static final String VERSION = "VERSION";
-	public static final String BY_DAVIDE = "by Davide Perini (VERSION)";
-	public static final String PRODUCING = "Producing @ ";
-	public static final String CONSUMING = "Consuming @ ";
 	public static final String FPS = "FPS";
 	public static final String PERCENT = "%";
 	public static final String GAMMA_DEFAULT = "2.2";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -147,7 +147,9 @@ public class Constants {
 	public static final String SERIAL_ERROR_TITLE = "Serial Port Error";
 	public static final String SERIAL_ERROR_HEADER = "No serial port available";
 	public static final String SERIAL_ERROR_OPEN_HEADER = "Can't open SERIAL PORT";
+	public static final String SERIAL_PORT_AMBIGUOUS = "Serial port is ambiguous";
 	public static final String SERIAL_ERROR_CONTEXT = "Serial port is in use or there is no microcontroller available. Please connect a microcontroller or go to settings and choose MQTT Stream. Luciferin restart is required.";
+	public static final String SERIAL_PORT_AMBIGUOUS_CONTEXT = "There is more than one device connected to your serial ports. Please go to \"Settings\", \"Mode\" and select the serial port you want to use.";
 	public static final String MQTT_ERROR_TITLE = "MQTT Connection Error";
 	public static final String MQTT_ERROR_HEADER = "Unable to connect to the MQTT server";
 	public static final String MQTT_ERROR_CONTEXT = "Luciferin is unable to connect to the MQTT server, please correct your settings and retry.";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -145,8 +145,8 @@ public class Constants {
 	public static final String SAVE = "Save";
 	public static final String SAVE_AND_CLOSE = "Save and close";
 	public static final String FRAMERATE_TITLE = "Framerate error";
-	public static final String FRAMERATE_HEADER = "Luciferin is out of sync";
-	public static final String FRAMERATE_CONTEXT = "Your computer is too fast and Glow Worm Luciferin firmware can't keep up. This can cause synchronization issues, please go to \"Settings\", \"Misc\" and lower the framerate.";
+	public static final String FRAMERATE_HEADER = "Firefly Luciferin is out of sync";
+	public static final String FRAMERATE_CONTEXT = "Your computer is capturing the screen too fast and Glow Worm Luciferin firmware can't keep up.\nThis can cause synchronization issues, please go to \"Settings\", \"Misc\" and lower the framerate.";
 	public static final String SERIAL_ERROR_TITLE = "Serial Port Error";
 	public static final String SERIAL_ERROR_HEADER = "No serial port available";
 	public static final String SERIAL_ERROR_OPEN_HEADER = "Can't open SERIAL PORT";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
 
 	// Misc
 	public static final String FIREFLY_LUCIFERIN = "Firefly Luciferin";
+	public static final int DEFAULT_BAUD_RATE = 1000000;
 	public static final String FULLSCREEN = "FullScreen";
 	public static final String LETTERBOX = "Letterbox";
 	public static final String SPAWNING_ROBOTS = "Spawning new robot for capture";

--- a/src/main/java/org/dpsoftware/grabber/GStreamerGrabber.java
+++ b/src/main/java/org/dpsoftware/grabber/GStreamerGrabber.java
@@ -72,7 +72,7 @@ public class GStreamerGrabber extends javax.swing.JComponent {
             gstreamerPipeline = Constants.GSTREAMER_PIPELINE;
         }
         // Huge amount of LEDs requires slower framerate
-        if (FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
+        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
             gstreamerPipeline += Constants.FRAMERATE_PLACEHOLDER.replaceAll("FRAMERATE_PLACEHOLDER", "10");
         } else {
             if (!Constants.UNLOCKED.equals(FireflyLuciferin.config.getDesiredFramerate())) {

--- a/src/main/java/org/dpsoftware/grabber/GStreamerGrabber.java
+++ b/src/main/java/org/dpsoftware/grabber/GStreamerGrabber.java
@@ -72,14 +72,10 @@ public class GStreamerGrabber extends javax.swing.JComponent {
             gstreamerPipeline = Constants.GSTREAMER_PIPELINE;
         }
         // Huge amount of LEDs requires slower framerate
-        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
-            gstreamerPipeline += Constants.FRAMERATE_PLACEHOLDER.replaceAll("FRAMERATE_PLACEHOLDER", "10");
+        if (!Constants.UNLOCKED.equals(FireflyLuciferin.config.getDesiredFramerate())) {
+            gstreamerPipeline += Constants.FRAMERATE_PLACEHOLDER.replaceAll("FRAMERATE_PLACEHOLDER", FireflyLuciferin.config.getDesiredFramerate());
         } else {
-            if (!Constants.UNLOCKED.equals(FireflyLuciferin.config.getDesiredFramerate())) {
-                gstreamerPipeline += Constants.FRAMERATE_PLACEHOLDER.replaceAll("FRAMERATE_PLACEHOLDER", FireflyLuciferin.config.getDesiredFramerate());
-            } else {
-                gstreamerPipeline += Constants.FRAMERATE_PLACEHOLDER.replaceAll("FRAMERATE_PLACEHOLDER", "144");
-            }
+            gstreamerPipeline += Constants.FRAMERATE_PLACEHOLDER.replaceAll("FRAMERATE_PLACEHOLDER", "144");
         }
         StringBuilder caps = new StringBuilder(gstreamerPipeline);
         // JNA creates ByteBuffer using native byte order, set masks according to that.

--- a/src/main/java/org/dpsoftware/grabber/GStreamerGrabber.java
+++ b/src/main/java/org/dpsoftware/grabber/GStreamerGrabber.java
@@ -67,7 +67,10 @@ public class GStreamerGrabber extends javax.swing.JComponent {
         videosink.connect(listener);
         String gstreamerPipeline;
         if (FireflyLuciferin.config.getCaptureMethod().equals(Configuration.CaptureMethod.DDUPL.name())) {
-            gstreamerPipeline = Constants.GSTREAMER_PIPELINE_DDUPL;
+            // Scale image inside the GPU by 2
+            gstreamerPipeline = Constants.GSTREAMER_PIPELINE_DDUPL
+                    .replace(Constants.INTERNAL_SCALING_X, String.valueOf(FireflyLuciferin.config.getScreenResX() / 2))
+                    .replace(Constants.INTERNAL_SCALING_Y, String.valueOf(FireflyLuciferin.config.getScreenResY() / 2));
         } else {
             gstreamerPipeline = Constants.GSTREAMER_PIPELINE;
         }
@@ -122,12 +125,13 @@ public class GStreamerGrabber extends javax.swing.JComponent {
                 // We need an ordered collection so no parallelStream here
                 ledMatrix.forEach((key, value) -> {
                     int r = 0, g = 0, b = 0;
-                    int skipPixel = 5;
+                    int skipPixel = 2;
                     // 6 pixel for X axis and 6 pixel for Y axis
                     int pixelToUse = 6;
                     int pickNumber = 0;
-                    int xCoordinate = value.getX();
-                    int yCoordinate = value.getY();
+                    // Image grabbed has been scaled by 2 inside the GPU, convert coordinate to match this scale
+                    int xCoordinate = value.getX() / 2;
+                    int yCoordinate = value.getY() / 2;
                     // We start with a negative offset
                     for (int x = 0; x < pixelToUse; x++) {
                         for (int y = 0; y < pixelToUse; y++) {

--- a/src/main/java/org/dpsoftware/gui/GUIManager.java
+++ b/src/main/java/org/dpsoftware/gui/GUIManager.java
@@ -323,6 +323,10 @@ public class GUIManager extends JFrame {
     public void stopCapturingThreads() {
 
         if (FireflyLuciferin.RUNNING) {
+            // lednum 0 will stop stream on the firmware immediately
+            if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream()) {
+                mqttManager.stream("{\"lednum\":0}");
+            }
             if (trayIcon != null) {
                 trayIcon.setImage(imageStop);
                 popup.remove(0);

--- a/src/main/java/org/dpsoftware/gui/GUIManager.java
+++ b/src/main/java/org/dpsoftware/gui/GUIManager.java
@@ -196,7 +196,7 @@ public class GUIManager extends JFrame {
                         try {
                             TimeUnit.SECONDS.sleep(4);
                             log.debug(Constants.CLEAN_EXIT);
-                            System.exit(0);
+                            FireflyLuciferin.exit();
                         } catch (InterruptedException e) {
                             log.error(e.getMessage());
                         }

--- a/src/main/java/org/dpsoftware/gui/GUIManager.java
+++ b/src/main/java/org/dpsoftware/gui/GUIManager.java
@@ -323,21 +323,25 @@ public class GUIManager extends JFrame {
     public void stopCapturingThreads() {
 
         if (FireflyLuciferin.RUNNING) {
-            // lednum 0 will stop stream on the firmware immediately
-            if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream()) {
-                mqttManager.stream("{\"lednum\":0}");
-            }
             if (trayIcon != null) {
                 trayIcon.setImage(imageStop);
                 popup.remove(0);
                 popup.insert(startItem, 0);
             }
             if (mqttManager != null) {
-                mqttManager.publishToTopic(FireflyLuciferin.config.getMqttTopic(), Constants.STATE_OFF_SOLID);
+                // lednum 0 will stop stream on the firmware immediately
+                if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream()) {
+                    mqttManager.stream("{\"lednum\":0}");
+                } else {
+                    mqttManager.publishToTopic(FireflyLuciferin.config.getMqttTopic(), Constants.STATE_OFF_SOLID);
+                }
                 try {
                     TimeUnit.SECONDS.sleep(4);
                 } catch (InterruptedException e) {
                     log.error(e.getMessage());
+                }
+                if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream()) {
+                    mqttManager.publishToTopic(FireflyLuciferin.config.getMqttTopic(), Constants.STATE_OFF_SOLID);
                 }
             }
             FireflyLuciferin.RUNNING = false;

--- a/src/main/java/org/dpsoftware/gui/GUIManager.java
+++ b/src/main/java/org/dpsoftware/gui/GUIManager.java
@@ -300,11 +300,6 @@ public class GUIManager extends JFrame {
                 stage.resizableProperty().setValue(Boolean.FALSE);
                 stage.setScene(scene);
                 stage.setTitle("  " + Constants.FIREFLY_LUCIFERIN);
-                if (stageName.equals(Constants.FXML_SETTINGS) || stageName.equals(Constants.FXML_SETTINGS_LINUX)) {
-                    if (!SystemTray.isSupported() || com.sun.jna.Platform.isLinux()) {
-                        stage.setOnCloseRequest(evt -> System.exit(0));
-                    }
-                }
                 setStageIcon(stage);
                 stage.show();
             } catch (IOException e) {

--- a/src/main/java/org/dpsoftware/gui/InfoController.java
+++ b/src/main/java/org/dpsoftware/gui/InfoController.java
@@ -70,9 +70,11 @@ public class InfoController {
 
         Platform.runLater(() -> {
             Stage stage = (Stage) splitPane.getScene().getWindow();
-            stage.setOnCloseRequest(evt -> {
-                animationTimer.stop();
-            });
+            if (stage != null) {
+                stage.setOnCloseRequest(evt -> {
+                    animationTimer.stop();
+                });
+            }
         });
 
     }

--- a/src/main/java/org/dpsoftware/gui/InfoController.java
+++ b/src/main/java/org/dpsoftware/gui/InfoController.java
@@ -90,7 +90,7 @@ public class InfoController {
             public void handle(long now) {
                 if (now - lastUpdate >= 1_000_000_000) {
                     setProducerValue("Producing @ " + FireflyLuciferin.FPS_PRODUCER + " FPS");
-                    setConsumerValue("Consuming @ " + (FireflyLuciferin.config.isMqttEnable() ? FireflyLuciferin.FPS_GW_CONSUMER : FireflyLuciferin.FPS_CONSUMER) + " FPS");
+                    setConsumerValue("Consuming @ " + FireflyLuciferin.FPS_GW_CONSUMER + " FPS");
                 }
             }
         };

--- a/src/main/java/org/dpsoftware/gui/InfoController.java
+++ b/src/main/java/org/dpsoftware/gui/InfoController.java
@@ -29,17 +29,25 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
+import javafx.scene.control.SplitPane;
 import javafx.scene.input.InputEvent;
 import javafx.stage.Stage;
+import lombok.extern.slf4j.Slf4j;
 import org.dpsoftware.FireflyLuciferin;
 
+/**
+ * FXML Info Controller
+ */
+@Slf4j
 public class InfoController {
 
+    @FXML private SplitPane splitPane;
     @FXML private Label producerLabel;
     @FXML private Label consumerLabel;
     @FXML private Label version;
     @FXML private final StringProperty producerValue = new SimpleStringProperty("");
     @FXML private final StringProperty consumerValue = new SimpleStringProperty("");
+    AnimationTimer animationTimer;
 
     @FXML
     protected void initialize() {
@@ -50,22 +58,52 @@ public class InfoController {
         consumerLabel.textProperty().bind(consumerValueProperty());
         UpgradeManager vm = new UpgradeManager();
         version.setText("by Davide Perini (VERSION)".replaceAll("VERSION", FireflyLuciferin.version));
-        new AnimationTimer() {
+        runLater();
+        startAnimationTimer();
+
+    }
+
+    /**
+     * Run Later after GUI Init
+     */
+    private void runLater() {
+
+        Platform.runLater(() -> {
+            Stage stage = (Stage) splitPane.getScene().getWindow();
+            stage.setOnCloseRequest(evt -> {
+                animationTimer.stop();
+            });
+        });
+
+    }
+
+    /**
+     * Manage animation timer to update the UI every seconds
+     */
+    private void startAnimationTimer() {
+
+        animationTimer = new AnimationTimer() {
+            private long lastUpdate = 0 ;
             @Override
             public void handle(long now) {
-                setProducerValue("Producing @ " + FireflyLuciferin.FPS_PRODUCER + " FPS");
-                setConsumerValue("Consuming @ " + (FireflyLuciferin.config.isMqttEnable() ? FireflyLuciferin.FPS_GW_CONSUMER : FireflyLuciferin.FPS_CONSUMER) + " FPS");
+                if (now - lastUpdate >= 1_000_000_000) {
+                    setProducerValue("Producing @ " + FireflyLuciferin.FPS_PRODUCER + " FPS");
+                    setConsumerValue("Consuming @ " + (FireflyLuciferin.config.isMqttEnable() ? FireflyLuciferin.FPS_GW_CONSUMER : FireflyLuciferin.FPS_CONSUMER) + " FPS");
+                }
             }
-        }.start();
+        };
+        animationTimer.start();
 
     }
 
     @FXML
     public void onMouseClickedCloseBtn(InputEvent e) {
 
+        animationTimer.stop();
         final Node source = (Node) e.getSource();
         final Stage stage = (Stage) source.getScene().getWindow();
         stage.hide();
+        animationTimer.stop();
 
     }
 

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -601,12 +601,14 @@ public class SettingsController {
      * Cancel button event
      */
     @FXML
-    public void cancel(InputEvent e) {
+    public void cancel(InputEvent event) {
 
-        animationTimer.stop();
-        final Node source = (Node) e.getSource();
-        final Stage stage = (Stage) source.getScene().getWindow();
-        stage.hide();
+        if (event != null) {
+            animationTimer.stop();
+            final Node source = (Node) event.getSource();
+            final Stage stage = (Stage) source.getScene().getWindow();
+            stage.hide();
+        }
 
     }
 

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -167,11 +167,11 @@ public class SettingsController {
         orientation.getItems().addAll(Constants.CLOCKWISE, Constants.ANTICLOCKWISE);
         aspectRatio.getItems().addAll(Constants.FULLSCREEN, Constants.LETTERBOX);
         framerate.getItems().addAll("10 FPS", "20 FPS", "30 FPS", "40 FPS", "50 FPS", "60 FPS", Constants.UNLOCKED);
-        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
-            framerate.setDisable(true);
-        }
         StorageManager sm = new StorageManager();
         Configuration currentConfig = sm.readConfig();
+        if (currentConfig != null && currentConfig.isMqttEnable() && currentConfig.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
+            framerate.setDisable(true);
+        }
         showTestImageButton.setVisible(currentConfig != null);
         setSaveButtonText(currentConfig);
         // Init default values
@@ -253,11 +253,15 @@ public class SettingsController {
             if ((toggleLed.isSelected())) {
                 toggleLed.setText(Constants.TURN_LED_OFF);
                 turnOnLEDs(currentConfig, true);
-                FireflyLuciferin.config.setToggleLed(true);
+                if (FireflyLuciferin.config != null) {
+                    FireflyLuciferin.config.setToggleLed(true);
+                }
             } else {
                 toggleLed.setText(Constants.TURN_LED_ON);
                 turnOffLEDs(currentConfig);
-                FireflyLuciferin.config.setToggleLed(false);
+                if (FireflyLuciferin.config != null) {
+                    FireflyLuciferin.config.setToggleLed(false);
+                }
             }
         });
         // Color picker listener
@@ -377,11 +381,7 @@ public class SettingsController {
             serialPort.setValue(Constants.SERIAL_PORT_AUTO);
             numberOfThreads.setText("1");
             aspectRatio.setValue(Constants.FULLSCREEN);
-            if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
-                framerate.setValue("10 FPS");
-            } else {
-                framerate.setValue("30 FPS");
-            }
+            framerate.setValue("30 FPS");
             mqttHost.setText(Constants.DEFAULT_MQTT_HOST);
             mqttPort.setText(Constants.DEFAULT_MQTT_PORT);
             mqttTopic.setText(Constants.DEFAULT_MQTT_TOPIC);
@@ -535,7 +535,7 @@ public class SettingsController {
         config.setGamma(Double.parseDouble(gamma.getValue()));
         config.setSerialPort(serialPort.getValue());
         config.setDefaultLedMatrix(aspectRatio.getValue());
-        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
+        if (FireflyLuciferin.config != null &&FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
             config.setDesiredFramerate("10");
         } else {
             config.setDesiredFramerate(framerate.getValue().equals(Constants.UNLOCKED) ? framerate.getValue() : framerate.getValue().substring(0,2));

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -200,13 +200,15 @@ public class SettingsController {
         if (com.sun.jna.Platform.isWindows()) {
             Platform.runLater(() -> {
                 Stage stage = (Stage) mainTabPane.getScene().getWindow();
-                stage.setOnCloseRequest(evt -> {
-                    if (!SystemTray.isSupported() || com.sun.jna.Platform.isLinux()) {
-                        System.exit(0);
-                    } else {
-                        animationTimer.stop();
-                    }
-                });
+                if (stage != null) {
+                    stage.setOnCloseRequest(evt -> {
+                        if (!SystemTray.isSupported() || com.sun.jna.Platform.isLinux()) {
+                            System.exit(0);
+                        } else {
+                            animationTimer.stop();
+                        }
+                    });
+                }
                 orientation.requestFocus();
             });
         }

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -110,6 +110,7 @@ public class SettingsController {
     @FXML private TableColumn<GlowWormDevice, String> deviceIPColumn;
     @FXML private TableColumn<GlowWormDevice, String> deviceVersionColumn;
     @FXML private TableColumn<GlowWormDevice, String> macColumn;
+    @FXML private TableColumn<GlowWormDevice, String> gpioColumn;
     @FXML private TableColumn<GlowWormDevice, String> numberOfLEDSconnectedColumn;
     @FXML private Label versionLabel;
     public static ObservableList<GlowWormDevice> deviceTableData = FXCollections.observableArrayList();
@@ -184,6 +185,7 @@ public class SettingsController {
         deviceIPColumn.setCellValueFactory(cellData -> cellData.getValue().deviceIPProperty());
         deviceVersionColumn.setCellValueFactory(cellData -> cellData.getValue().deviceVersionProperty());
         macColumn.setCellValueFactory(cellData -> cellData.getValue().macProperty());
+        gpioColumn.setCellValueFactory(cellData -> cellData.getValue().gpioProperty());
         numberOfLEDSconnectedColumn.setCellValueFactory(cellData -> cellData.getValue().numberOfLEDSconnectedProperty());
         deviceTable.setItems(getDeviceTableData());
         initListeners(currentConfig);

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -242,8 +242,8 @@ public class SettingsController {
                         deviceTableData.removeAll(deviceTableDataToRemove);
                         deviceTable.refresh();
                     } else {
-                        setProducerValue(Constants.PRODUCING + FireflyLuciferin.FPS_PRODUCER + " " + Constants.FPS);
-                        setConsumerValue(Constants.CONSUMING + FireflyLuciferin.FPS_CONSUMER + " " + Constants.FPS);
+                        setProducerValue("Producing @ " + FireflyLuciferin.FPS_PRODUCER + " FPS");
+                        setConsumerValue("Consuming @ " + (FireflyLuciferin.config.isMqttEnable() ? FireflyLuciferin.FPS_GW_CONSUMER : FireflyLuciferin.FPS_CONSUMER) + " FPS");
                     }
                 }
             }

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -217,31 +217,15 @@ public class SettingsController {
      */
     private void startAnimationTimer() {
 
-        Calendar calendar = Calendar.getInstance();
         animationTimer = new AnimationTimer() {
             private long lastUpdate = 0 ;
             @Override
             public void handle(long now) {
                 if (now - lastUpdate >= 1_000_000_000) {
                     if (com.sun.jna.Platform.isWindows()) {
-                        lastUpdate = now;
-                        ObservableList<GlowWormDevice> deviceTableDataToRemove = FXCollections.observableArrayList();
-                        deviceTableData.forEach(glowWormDevice -> {
-                            calendar.setTime(new Date());
-                            calendar.add(Calendar.SECOND, -30);
-                            try {
-                                log.debug(calendar.getTime() + "");
-                                log.debug(String.valueOf(FireflyLuciferin.formatter.parse(glowWormDevice.getLastSeen())));
-                                if (calendar.getTime().after(FireflyLuciferin.formatter.parse(glowWormDevice.getLastSeen()))) {
-                                    deviceTableDataToRemove.add(glowWormDevice);
-                                }
-                            } catch (ParseException e) {
-                                log.error(e.getMessage());
-                            }
-                        });
-                        deviceTableData.removeAll(deviceTableDataToRemove);
-                        deviceTable.refresh();
+                        manageDeviceList();
                     } else {
+                        manageDeviceList();
                         setProducerValue("Producing @ " + FireflyLuciferin.FPS_PRODUCER + " FPS");
                         setConsumerValue("Consuming @ " + (FireflyLuciferin.config.isMqttEnable() ? FireflyLuciferin.FPS_GW_CONSUMER : FireflyLuciferin.FPS_CONSUMER) + " FPS");
                     }
@@ -283,6 +267,31 @@ public class SettingsController {
         });
         brightness.valueProperty().addListener((ov, old_val, new_val) -> turnOnLEDs(currentConfig, false));
         splitBottomRow.setOnAction(e -> splitBottomRow());
+
+    }
+
+    /**
+     * Manage the device list tab update
+     */
+    void manageDeviceList() {
+
+        Calendar calendar = Calendar.getInstance();
+        ObservableList<GlowWormDevice> deviceTableDataToRemove = FXCollections.observableArrayList();
+        deviceTableData.forEach(glowWormDevice -> {
+            calendar.setTime(new Date());
+            calendar.add(Calendar.SECOND, -20);
+            try {
+                log.debug(calendar.getTime() + "");
+                log.debug(String.valueOf(FireflyLuciferin.formatter.parse(glowWormDevice.getLastSeen())));
+                if (calendar.getTime().after(FireflyLuciferin.formatter.parse(glowWormDevice.getLastSeen()))) {
+                    deviceTableDataToRemove.add(glowWormDevice);
+                }
+            } catch (ParseException e) {
+                log.error(e.getMessage());
+            }
+        });
+        deviceTableData.removeAll(deviceTableDataToRemove);
+        deviceTable.refresh();
 
     }
 

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -424,11 +424,7 @@ public class SettingsController {
         serialPort.setValue(currentConfig.getSerialPort());
         numberOfThreads.setText(String.valueOf(currentConfig.getNumberOfCPUThreads()));
         aspectRatio.setValue(currentConfig.getDefaultLedMatrix());
-//        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
-//            framerate.setValue("10 FPS");
-//        } else {
-            framerate.setValue(currentConfig.getDesiredFramerate() + ((currentConfig.getDesiredFramerate().equals(Constants.UNLOCKED)) ? "" : " FPS"));
-//        }
+        framerate.setValue(currentConfig.getDesiredFramerate() + ((currentConfig.getDesiredFramerate().equals(Constants.UNLOCKED)) ? "" : " FPS"));
         mqttHost.setText(currentConfig.getMqttServer().substring(0, currentConfig.getMqttServer().lastIndexOf(":")));
         mqttPort.setText(currentConfig.getMqttServer().substring(currentConfig.getMqttServer().lastIndexOf(":") + 1));
         mqttTopic.setText(currentConfig.getMqttTopic());
@@ -532,11 +528,7 @@ public class SettingsController {
         config.setGamma(Double.parseDouble(gamma.getValue()));
         config.setSerialPort(serialPort.getValue());
         config.setDefaultLedMatrix(aspectRatio.getValue());
-//        if (FireflyLuciferin.config != null &&FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.SECOND_CHUNK) {
-//            config.setDesiredFramerate("10");
-//        } else {
-            config.setDesiredFramerate(framerate.getValue().equals(Constants.UNLOCKED) ? framerate.getValue() : framerate.getValue().substring(0,2));
-//        }
+        config.setDesiredFramerate(framerate.getValue().equals(Constants.UNLOCKED) ? framerate.getValue() : framerate.getValue().substring(0,2));
         config.setMqttServer(mqttHost.getText() + ":" + mqttPort.getText());
         config.setMqttTopic(mqttTopic.getText());
         config.setMqttUsername(mqttUser.getText());

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -224,7 +224,6 @@ public class SettingsController {
             public void handle(long now) {
                 if (now - lastUpdate >= 1_000_000_000) {
                     lastUpdate = now;
-
                     if (com.sun.jna.Platform.isWindows()) {
                         manageDeviceList();
                     } else {
@@ -284,8 +283,6 @@ public class SettingsController {
             calendar.setTime(new Date());
             calendar.add(Calendar.SECOND, -20);
             try {
-                log.debug(calendar.getTime() + "");
-                log.debug(String.valueOf(FireflyLuciferin.formatter.parse(glowWormDevice.getLastSeen())));
                 if (calendar.getTime().after(FireflyLuciferin.formatter.parse(glowWormDevice.getLastSeen()))) {
                     deviceTableDataToRemove.add(glowWormDevice);
                 }

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -161,6 +161,7 @@ public class SettingsController {
                 serialPort.getItems().add(Constants.SERIAL_PORT_TTY + i);
             }
             captureMethod.getItems().addAll(Configuration.CaptureMethod.XIMAGESRC);
+            version.setText("by Davide Perini (VERSION)".replaceAll("VERSION", FireflyLuciferin.version));
         }
         orientation.getItems().addAll(Constants.CLOCKWISE, Constants.ANTICLOCKWISE);
         aspectRatio.getItems().addAll(Constants.FULLSCREEN, Constants.LETTERBOX);

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -222,6 +222,8 @@ public class SettingsController {
             @Override
             public void handle(long now) {
                 if (now - lastUpdate >= 1_000_000_000) {
+                    lastUpdate = now;
+
                     if (com.sun.jna.Platform.isWindows()) {
                         manageDeviceList();
                     } else {

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -106,6 +106,7 @@ public class SettingsController {
     @FXML private final StringProperty consumerValue = new SimpleStringProperty("");
     @FXML private TableView<GlowWormDevice> deviceTable;
     @FXML private TableColumn<GlowWormDevice, String> deviceNameColumn;
+    @FXML private TableColumn<GlowWormDevice, String> deviceBoardColumn;
     @FXML private TableColumn<GlowWormDevice, String> deviceIPColumn;
     @FXML private TableColumn<GlowWormDevice, String> deviceVersionColumn;
     @FXML private TableColumn<GlowWormDevice, String> macColumn;
@@ -166,7 +167,7 @@ public class SettingsController {
         orientation.getItems().addAll(Constants.CLOCKWISE, Constants.ANTICLOCKWISE);
         aspectRatio.getItems().addAll(Constants.FULLSCREEN, Constants.LETTERBOX);
         framerate.getItems().addAll("10 FPS", "20 FPS", "30 FPS", "40 FPS", "50 FPS", "60 FPS", Constants.UNLOCKED);
-        if (FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
+        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
             framerate.setDisable(true);
         }
         StorageManager sm = new StorageManager();
@@ -182,6 +183,7 @@ public class SettingsController {
         runLater();
         // Device table
         deviceNameColumn.setCellValueFactory(cellData -> cellData.getValue().deviceNameProperty());
+        deviceBoardColumn.setCellValueFactory(cellData -> cellData.getValue().deviceBoardProperty());
         deviceIPColumn.setCellValueFactory(cellData -> cellData.getValue().deviceIPProperty());
         deviceVersionColumn.setCellValueFactory(cellData -> cellData.getValue().deviceVersionProperty());
         macColumn.setCellValueFactory(cellData -> cellData.getValue().macProperty());
@@ -203,7 +205,7 @@ public class SettingsController {
                 if (stage != null) {
                     stage.setOnCloseRequest(evt -> {
                         if (!SystemTray.isSupported() || com.sun.jna.Platform.isLinux()) {
-                            System.exit(0);
+                            FireflyLuciferin.exit();
                         } else {
                             animationTimer.stop();
                         }
@@ -231,7 +233,7 @@ public class SettingsController {
                     } else {
                         manageDeviceList();
                         setProducerValue("Producing @ " + FireflyLuciferin.FPS_PRODUCER + " FPS");
-                        setConsumerValue("Consuming @ " + (FireflyLuciferin.config.isMqttEnable() ? FireflyLuciferin.FPS_GW_CONSUMER : FireflyLuciferin.FPS_CONSUMER) + " FPS");
+                        setConsumerValue("Consuming @ " + FireflyLuciferin.FPS_GW_CONSUMER + " FPS");
                     }
                 }
             }
@@ -369,7 +371,7 @@ public class SettingsController {
             serialPort.setValue(Constants.SERIAL_PORT_AUTO);
             numberOfThreads.setText("1");
             aspectRatio.setValue(Constants.FULLSCREEN);
-            if (FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
+            if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
                 framerate.setValue("10 FPS");
             } else {
                 framerate.setValue("30 FPS");
@@ -419,7 +421,7 @@ public class SettingsController {
         serialPort.setValue(currentConfig.getSerialPort());
         numberOfThreads.setText(String.valueOf(currentConfig.getNumberOfCPUThreads()));
         aspectRatio.setValue(currentConfig.getDefaultLedMatrix());
-        if (FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
+        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
             framerate.setValue("10 FPS");
         } else {
             framerate.setValue(currentConfig.getDesiredFramerate() + ((currentConfig.getDesiredFramerate().equals(Constants.UNLOCKED)) ? "" : " FPS"));
@@ -527,7 +529,7 @@ public class SettingsController {
         config.setGamma(Double.parseDouble(gamma.getValue()));
         config.setSerialPort(serialPort.getValue());
         config.setDefaultLedMatrix(aspectRatio.getValue());
-        if (FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
+        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
             config.setDesiredFramerate("10");
         } else {
             config.setDesiredFramerate(framerate.getValue().equals(Constants.UNLOCKED) ? framerate.getValue() : framerate.getValue().substring(0,2));
@@ -591,7 +593,7 @@ public class SettingsController {
                     log.error(e.getMessage());
                 }
             }
-            System.exit(0);
+            FireflyLuciferin.exit();
         } catch (InterruptedException e) {
             log.error(e.getMessage());
         }

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -167,7 +167,7 @@ public class SettingsController {
         }
         orientation.getItems().addAll(Constants.CLOCKWISE, Constants.ANTICLOCKWISE);
         aspectRatio.getItems().addAll(Constants.FULLSCREEN, Constants.LETTERBOX);
-        framerate.getItems().addAll("10 FPS", "15 FPS", "20 FPS", "25 FPS", "30 FPS", "40 FPS", "50 FPS", "60 FPS", Constants.UNLOCKED);
+        framerate.getItems().addAll("5 FPS", "10 FPS", "15 FPS", "20 FPS", "25 FPS", "30 FPS", "40 FPS", "50 FPS", "60 FPS", Constants.UNLOCKED);
         StorageManager sm = new StorageManager();
         Configuration currentConfig = sm.readConfig();
         showTestImageButton.setVisible(currentConfig != null);
@@ -530,7 +530,8 @@ public class SettingsController {
         config.setGamma(Double.parseDouble(gamma.getValue()));
         config.setSerialPort(serialPort.getValue());
         config.setDefaultLedMatrix(aspectRatio.getValue());
-        config.setDesiredFramerate(framerate.getValue().equals(Constants.UNLOCKED) ? framerate.getValue() : framerate.getValue().substring(0,2));
+        config.setDesiredFramerate(framerate.getValue().equals(Constants.UNLOCKED) ?
+                framerate.getValue() : framerate.getValue().split(" ")[0]);
         config.setMqttServer(mqttHost.getText() + ":" + mqttPort.getText());
         config.setMqttTopic(mqttTopic.getText());
         config.setMqttUsername(mqttUser.getText());

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -273,6 +273,12 @@ public class SettingsController {
         });
         brightness.valueProperty().addListener((ov, old_val, new_val) -> turnOnLEDs(currentConfig, false));
         splitBottomRow.setOnAction(e -> splitBottomRow());
+        mqttEnable.setOnAction(e -> {
+            if (!mqttEnable.isSelected()) mqttStream.setSelected(false);
+        });
+        mqttStream.setOnAction(e -> {
+            if (mqttStream.isSelected()) mqttEnable.setSelected(true);
+        });
 
     }
 

--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -166,12 +166,9 @@ public class SettingsController {
         }
         orientation.getItems().addAll(Constants.CLOCKWISE, Constants.ANTICLOCKWISE);
         aspectRatio.getItems().addAll(Constants.FULLSCREEN, Constants.LETTERBOX);
-        framerate.getItems().addAll("10 FPS", "20 FPS", "30 FPS", "40 FPS", "50 FPS", "60 FPS", Constants.UNLOCKED);
+        framerate.getItems().addAll("10 FPS", "15 FPS", "20 FPS", "25 FPS", "30 FPS", "40 FPS", "50 FPS", "60 FPS", Constants.UNLOCKED);
         StorageManager sm = new StorageManager();
         Configuration currentConfig = sm.readConfig();
-        if (currentConfig != null && currentConfig.isMqttEnable() && currentConfig.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
-            framerate.setDisable(true);
-        }
         showTestImageButton.setVisible(currentConfig != null);
         setSaveButtonText(currentConfig);
         // Init default values
@@ -427,11 +424,11 @@ public class SettingsController {
         serialPort.setValue(currentConfig.getSerialPort());
         numberOfThreads.setText(String.valueOf(currentConfig.getNumberOfCPUThreads()));
         aspectRatio.setValue(currentConfig.getDefaultLedMatrix());
-        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
-            framerate.setValue("10 FPS");
-        } else {
+//        if (FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
+//            framerate.setValue("10 FPS");
+//        } else {
             framerate.setValue(currentConfig.getDesiredFramerate() + ((currentConfig.getDesiredFramerate().equals(Constants.UNLOCKED)) ? "" : " FPS"));
-        }
+//        }
         mqttHost.setText(currentConfig.getMqttServer().substring(0, currentConfig.getMqttServer().lastIndexOf(":")));
         mqttPort.setText(currentConfig.getMqttServer().substring(currentConfig.getMqttServer().lastIndexOf(":") + 1));
         mqttTopic.setText(currentConfig.getMqttTopic());
@@ -535,11 +532,11 @@ public class SettingsController {
         config.setGamma(Double.parseDouble(gamma.getValue()));
         config.setSerialPort(serialPort.getValue());
         config.setDefaultLedMatrix(aspectRatio.getValue());
-        if (FireflyLuciferin.config != null &&FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.FIRST_CHUNK) {
-            config.setDesiredFramerate("10");
-        } else {
+//        if (FireflyLuciferin.config != null &&FireflyLuciferin.config.isMqttEnable() && FireflyLuciferin.config.isMqttStream() && FireflyLuciferin.ledNumber > Constants.SECOND_CHUNK) {
+//            config.setDesiredFramerate("10");
+//        } else {
             config.setDesiredFramerate(framerate.getValue().equals(Constants.UNLOCKED) ? framerate.getValue() : framerate.getValue().substring(0,2));
-        }
+//        }
         config.setMqttServer(mqttHost.getText() + ":" + mqttPort.getText());
         config.setMqttTopic(mqttTopic.getText());
         config.setMqttUsername(mqttUser.getText());

--- a/src/main/java/org/dpsoftware/gui/UpgradeManager.java
+++ b/src/main/java/org/dpsoftware/gui/UpgradeManager.java
@@ -293,8 +293,16 @@ public class UpgradeManager {
                                     deviceContent + deviceToUpdateStr + Constants.UPDATE_BACKGROUND + "\n", Alert.AlertType.CONFIRMATION);
                             ButtonType button = result.orElse(ButtonType.OK);
                             if (button == ButtonType.OK) {
-                                FireflyLuciferin.guiManager.mqttManager.publishToTopic(Constants.UPDATE_MQTT_TOPIC, Constants.START_WEB_SERVER_MSG);
-                                devicesToUpdate.forEach(this::executeUpdate);
+                                try {
+                                    if (FireflyLuciferin.RUNNING) {
+                                        FireflyLuciferin.guiManager.stopCapturingThreads();
+                                        TimeUnit.SECONDS.sleep(15);
+                                    }
+                                    FireflyLuciferin.guiManager.mqttManager.publishToTopic(Constants.UPDATE_MQTT_TOPIC, Constants.START_WEB_SERVER_MSG);
+                                    devicesToUpdate.forEach(this::executeUpdate);
+                                } catch (InterruptedException e) {
+                                    log.error(e.getMessage());
+                                }
                             }
                         });
                     }

--- a/src/main/java/org/dpsoftware/gui/UpgradeManager.java
+++ b/src/main/java/org/dpsoftware/gui/UpgradeManager.java
@@ -73,7 +73,10 @@ public class UpgradeManager {
     String latestReleaseStr = "";
 
     /**
-     * Check for Update
+     * Check for Glow Worm Luciferin or Firefly Luciferin update on GitHub
+     * @param urlToVerionFile
+     * @param currentVersion
+     * @param rawText
      * @return true if there is a new release
      */
     public boolean checkForUpdate(String urlToVerionFile, String currentVersion, boolean rawText) {
@@ -223,34 +226,25 @@ public class UpgradeManager {
      */
     boolean checkFireflyUpdates(Stage stage, GUIManager guiManager) {
 
-        log.debug("Checking for Firefly Luciferin Update");
-        boolean fireflyUpdate = checkForUpdate(Constants.GITHUB_POM_URL, FireflyLuciferin.version, false);
-        if (FireflyLuciferin.config.isCheckForUpdates() && fireflyUpdate) {
-            String upgradeContext;
-            if (com.sun.jna.Platform.isWindows()) {
-                if (FireflyLuciferin.config.isMqttEnable()) {
+        boolean fireflyUpdate = false;
+        if (FireflyLuciferin.config.isCheckForUpdates()) {
+            log.debug("Checking for Firefly Luciferin Update");
+            fireflyUpdate = checkForUpdate(Constants.GITHUB_POM_URL, FireflyLuciferin.version, false);
+            if (fireflyUpdate) {
+                String upgradeContext;
+                if (com.sun.jna.Platform.isWindows()) {
                     upgradeContext = Constants.CLICK_OK_DOWNLOAD;
-                } else {
-                    upgradeContext = Constants.CLICK_OK_DOWNLOAD_LIGHT;
-                }
-            } else if (com.sun.jna.Platform.isMac()) {
-                if (FireflyLuciferin.config.isMqttEnable()) {
+                } else if (com.sun.jna.Platform.isMac()) {
                     upgradeContext = Constants.CLICK_OK_DOWNLOAD_LINUX + Constants.ONCE_DOWNLOAD_FINISHED;
                 } else {
-                    upgradeContext = Constants.CLICK_OK_DOWNLOAD_LINUX + Constants.ONCE_DOWNLOAD_FINISHED_LIGHT;
-                }
-            } else {
-                if (FireflyLuciferin.config.isMqttEnable()) {
                     upgradeContext = Constants.CLICK_OK_DOWNLOAD_LINUX + Constants.ONCE_DOWNLOAD_FINISHED;
-                } else {
-                    upgradeContext = Constants.CLICK_OK_DOWNLOAD_LINUX + Constants.ONCE_DOWNLOAD_FINISHED_LIGHT;
                 }
-            }
-            Optional<ButtonType> result = guiManager.showAlert(Constants.FIREFLY_LUCIFERIN, Constants.NEW_VERSION_AVAILABLE,
-                    upgradeContext, Alert.AlertType.CONFIRMATION);
-            ButtonType button = result.orElse(ButtonType.OK);
-            if (button == ButtonType.OK) {
-                downloadNewVersion(stage);
+                Optional<ButtonType> result = guiManager.showAlert(Constants.FIREFLY_LUCIFERIN, Constants.NEW_VERSION_AVAILABLE,
+                        upgradeContext, Alert.AlertType.CONFIRMATION);
+                ButtonType button = result.orElse(ButtonType.OK);
+                if (button == ButtonType.OK) {
+                    downloadNewVersion(stage);
+                }
             }
         }
         return fireflyUpdate;
@@ -270,8 +264,14 @@ public class UpgradeManager {
                 log.debug("Checking for Glow Worm Luciferin Update");
                 if (!SettingsController.deviceTableData.isEmpty()) {
                     ArrayList<GlowWormDevice> devicesToUpdate = new ArrayList<>();
+                    // Updating MQTT devices for FULL firmware or Serial devices for LIGHT firmware
                     SettingsController.deviceTableData.forEach(glowWormDevice -> {
-                        if (!glowWormDevice.getDeviceName().equals(Constants.USB_DEVICE)) {
+                        if ((FireflyLuciferin.config.isMqttEnable() && !glowWormDevice.getDeviceName().equals(Constants.USB_DEVICE))
+                                || !FireflyLuciferin.config.isMqttEnable()) {
+                            // USB Serial device prior to 4.3.8 and there is no version information, needs the update so fake the version
+                            if (glowWormDevice.getDeviceVersion().equals(Constants.DASH)) {
+                                glowWormDevice.setDeviceVersion(Constants.LIGHT_FIRMWARE_DUMMY_VERSION);
+                            }
                             if (checkForUpdate(Constants.GITHUB_GLOW_WORM_URL, glowWormDevice.getDeviceVersion(), true)) {
                                 devicesToUpdate.add(glowWormDevice);
                             }
@@ -285,23 +285,26 @@ public class UpgradeManager {
                                     .collect(Collectors.joining());
                             String deviceContent;
                             if (devicesToUpdate.size() == 1) {
-                                deviceContent = Constants.DEVICE_UPDATED;
+                                deviceContent = FireflyLuciferin.config.isMqttEnable() ? Constants.DEVICE_UPDATED : Constants.DEVICE_UPDATED_LIGHT;
                             } else {
                                 deviceContent = Constants.DEVICES_UPDATED;
                             }
                             Optional<ButtonType> result = guiManager.showAlert(Constants.FIREFLY_LUCIFERIN, Constants.NEW_FIRMWARE_AVAILABLE,
-                                    deviceContent + deviceToUpdateStr + Constants.UPDATE_BACKGROUND + "\n", Alert.AlertType.CONFIRMATION);
-                            ButtonType button = result.orElse(ButtonType.OK);
-                            if (button == ButtonType.OK) {
-                                try {
-                                    if (FireflyLuciferin.RUNNING) {
-                                        FireflyLuciferin.guiManager.stopCapturingThreads();
-                                        TimeUnit.SECONDS.sleep(15);
+                                    deviceContent + deviceToUpdateStr + (FireflyLuciferin.config.isMqttEnable() ? Constants.UPDATE_BACKGROUND : Constants.UPDATE_NEEDED)
+                                            + "\n", FireflyLuciferin.config.isMqttEnable() ? Alert.AlertType.CONFIRMATION : Alert.AlertType.INFORMATION);
+                            if (FireflyLuciferin.config.isMqttEnable()) {
+                                ButtonType button = result.orElse(ButtonType.OK);
+                                if (button == ButtonType.OK) {
+                                    try {
+                                        if (FireflyLuciferin.RUNNING) {
+                                            FireflyLuciferin.guiManager.stopCapturingThreads();
+                                            TimeUnit.SECONDS.sleep(15);
+                                        }
+                                        FireflyLuciferin.guiManager.mqttManager.publishToTopic(Constants.UPDATE_MQTT_TOPIC, Constants.START_WEB_SERVER_MSG);
+                                        devicesToUpdate.forEach(this::executeUpdate);
+                                    } catch (InterruptedException e) {
+                                        log.error(e.getMessage());
                                     }
-                                    FireflyLuciferin.guiManager.mqttManager.publishToTopic(Constants.UPDATE_MQTT_TOPIC, Constants.START_WEB_SERVER_MSG);
-                                    devicesToUpdate.forEach(this::executeUpdate);
-                                } catch (InterruptedException e) {
-                                    log.error(e.getMessage());
                                 }
                             }
                         });

--- a/src/main/java/org/dpsoftware/gui/UpgradeManager.java
+++ b/src/main/java/org/dpsoftware/gui/UpgradeManager.java
@@ -204,7 +204,7 @@ public class UpgradeManager {
                     if (Platform.isWindows()) {
                         Runtime.getRuntime().exec(downloadPath);
                     }
-                    System.exit(0);
+                    FireflyLuciferin.exit();
                 } catch (IOException e) {
                     log.error(e.getMessage());
                 }

--- a/src/main/java/org/dpsoftware/gui/elements/GlowWormDevice.java
+++ b/src/main/java/org/dpsoftware/gui/elements/GlowWormDevice.java
@@ -31,20 +31,22 @@ public class GlowWormDevice {
     private final SimpleStringProperty deviceVersion = new SimpleStringProperty("");
     private final SimpleStringProperty deviceBoard = new SimpleStringProperty("");
     private final SimpleStringProperty mac = new SimpleStringProperty("");
+    private final SimpleStringProperty gpio = new SimpleStringProperty("");
     private final SimpleStringProperty numberOfLEDSconnected = new SimpleStringProperty("");
     private final SimpleStringProperty lastSeen = new SimpleStringProperty("");
 
     public GlowWormDevice() {
-        this("", "", "", "", "", "", "");
+        this("", "", "", "", "", "", "", "");
     }
 
     public GlowWormDevice(String deviceName, String deviceIP, String deviceVersion, String deviceBoard,
-                          String mac, String numberOfLEDSconnected, String lastSeen) {
+                          String mac, String gpio, String numberOfLEDSconnected, String lastSeen) {
         setDeviceName(deviceName);
         setDeviceIP(deviceIP);
         setDeviceVersion(deviceVersion);
         setDeviceBoard(deviceBoard);
         setMac(mac);
+        setGpio(gpio);
         setNumberOfLEDSconnected(numberOfLEDSconnected);
         setLastSeen(lastSeen);
     }
@@ -107,6 +109,18 @@ public class GlowWormDevice {
 
     public StringProperty macProperty() {
         return mac;
+    }
+
+    public String getGpio() {
+        return gpio.get();
+    }
+
+    public void setGpio(String gpioStr) {
+        gpio.set(gpioStr);
+    }
+
+    public StringProperty gpioProperty() {
+        return gpio;
     }
 
     public String getNumberOfLEDSconnected() {

--- a/src/main/java/org/dpsoftware/gui/elements/GlowWormDevice.java
+++ b/src/main/java/org/dpsoftware/gui/elements/GlowWormDevice.java
@@ -32,18 +32,21 @@ public class GlowWormDevice {
     private final SimpleStringProperty deviceBoard = new SimpleStringProperty("");
     private final SimpleStringProperty mac = new SimpleStringProperty("");
     private final SimpleStringProperty numberOfLEDSconnected = new SimpleStringProperty("");
+    private final SimpleStringProperty lastSeen = new SimpleStringProperty("");
 
     public GlowWormDevice() {
-        this("", "", "", "", "", "");
+        this("", "", "", "", "", "", "");
     }
 
-    public GlowWormDevice(String deviceName, String deviceIP, String deviceVersion, String deviceBoard, String mac, String numberOfLEDSconnected) {
+    public GlowWormDevice(String deviceName, String deviceIP, String deviceVersion, String deviceBoard,
+                          String mac, String numberOfLEDSconnected, String lastSeen) {
         setDeviceName(deviceName);
         setDeviceIP(deviceIP);
         setDeviceVersion(deviceVersion);
         setDeviceBoard(deviceBoard);
         setMac(mac);
         setNumberOfLEDSconnected(numberOfLEDSconnected);
+        setLastSeen(lastSeen);
     }
 
     public String getDeviceName() {
@@ -116,6 +119,18 @@ public class GlowWormDevice {
 
     public StringProperty numberOfLEDSconnectedProperty() {
         return numberOfLEDSconnected;
+    }
+
+    public String getLastSeen() {
+        return lastSeen.get();
+    }
+
+    public void setLastSeen(String lastSeenStr) {
+        lastSeen.set(lastSeenStr);
+    }
+
+    public StringProperty lastSeenProperty() {
+        return lastSeen;
     }
 
 }

--- a/src/main/resources/org/dpsoftware/gui/info.fxml
+++ b/src/main/resources/org/dpsoftware/gui/info.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.*?>
 
-<SplitPane id="infopane" dividerPositions="0.5" scaleShape="false" style="-fx-background-color: transparent;" stylesheets="@css/main.css" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.dpsoftware.gui.InfoController">
+<SplitPane fx:id="splitPane" id="infopane" dividerPositions="0.5" scaleShape="false" style="-fx-background-color: transparent;" stylesheets="@css/main.css" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.dpsoftware.gui.InfoController">
    <cursor>
       <Cursor fx:constant="DEFAULT" />
    </cursor>

--- a/src/main/resources/org/dpsoftware/gui/linuxSettings.fxml
+++ b/src/main/resources/org/dpsoftware/gui/linuxSettings.fxml
@@ -451,6 +451,7 @@
                      <TableColumn fx:id="deviceVersionColumn" prefWidth="40.6666259765625" text="Ver" />
                      <TableColumn fx:id="deviceBoardColumn" prefWidth="60.6666259765625" text="Board" />
                      <TableColumn fx:id="macColumn" prefWidth="105.66668450832367" text="MAC" />
+                     <TableColumn fx:id="gpioColumn" prefWidth="40.66668450832367" text="GPIO" />
                      <TableColumn fx:id="numberOfLEDSconnectedColumn" prefWidth="45.6666259765625" text="LEDs #" />
                   </columns>
                </TableView>

--- a/src/main/resources/org/dpsoftware/gui/linuxSettings.fxml
+++ b/src/main/resources/org/dpsoftware/gui/linuxSettings.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.paint.*?>
 <?import javafx.scene.text.*?>
 
-<TabPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="415.0" prefWidth="400.0" tabClosingPolicy="UNAVAILABLE" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.dpsoftware.gui.SettingsController">
+<TabPane fx:id="mainTabPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="415.0" prefWidth="400.0" tabClosingPolicy="UNAVAILABLE" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.dpsoftware.gui.SettingsController">
    <Tab text="Controls">
       <content>
 

--- a/src/main/resources/org/dpsoftware/gui/linuxSettings.fxml
+++ b/src/main/resources/org/dpsoftware/gui/linuxSettings.fxml
@@ -449,6 +449,7 @@
                      <TableColumn fx:id="deviceNameColumn" prefWidth="136.66668450832367" text="Device Name" />
                      <TableColumn fx:id="deviceIPColumn" prefWidth="74.0000228881836" text="IP/SERIAL" />
                      <TableColumn fx:id="deviceVersionColumn" prefWidth="40.6666259765625" text="Ver" />
+                     <TableColumn fx:id="deviceBoardColumn" prefWidth="60.6666259765625" text="Board" />
                      <TableColumn fx:id="macColumn" prefWidth="105.66668450832367" text="MAC" />
                      <TableColumn fx:id="numberOfLEDSconnectedColumn" prefWidth="45.6666259765625" text="LEDs #" />
                   </columns>

--- a/src/main/resources/org/dpsoftware/gui/settings.fxml
+++ b/src/main/resources/org/dpsoftware/gui/settings.fxml
@@ -378,6 +378,7 @@
                     <TableColumn fx:id="deviceNameColumn" prefWidth="136.66668450832367" text="Device Name" />
                     <TableColumn fx:id="deviceIPColumn" prefWidth="74.0000228881836" text="IP/SERIAL" />
                     <TableColumn fx:id="deviceVersionColumn" prefWidth="40.6666259765625" text="Ver" />
+                    <TableColumn fx:id="deviceBoardColumn" prefWidth="60.6666259765625" text="Board" />
                     <TableColumn fx:id="macColumn" prefWidth="105.66668450832367" text="MAC" />
                     <TableColumn fx:id="numberOfLEDSconnectedColumn" prefWidth="45.6666259765625" text="LEDs #" />
                  </columns>

--- a/src/main/resources/org/dpsoftware/gui/settings.fxml
+++ b/src/main/resources/org/dpsoftware/gui/settings.fxml
@@ -370,7 +370,7 @@
                <CheckBox fx:id="checkForUpdates" mnemonicParsing="false" GridPane.columnIndex="1" GridPane.rowIndex="2" />
                <Button fx:id="saveDeviceButton" mnemonicParsing="false" onMouseClicked="#save" text="Save and close" GridPane.columnIndex="1" GridPane.rowIndex="3">
                   <GridPane.margin>
-                     <Insets left="158.0" top="-5.0" />
+                     <Insets left="157.0" top="-5.0" />
                   </GridPane.margin>
                </Button>
                <TableView fx:id="deviceTable" prefHeight="200.0" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="1">

--- a/src/main/resources/org/dpsoftware/gui/settings.fxml
+++ b/src/main/resources/org/dpsoftware/gui/settings.fxml
@@ -380,6 +380,7 @@
                     <TableColumn fx:id="deviceVersionColumn" prefWidth="40.6666259765625" text="Ver" />
                     <TableColumn fx:id="deviceBoardColumn" prefWidth="60.6666259765625" text="Board" />
                     <TableColumn fx:id="macColumn" prefWidth="105.66668450832367" text="MAC" />
+                    <TableColumn fx:id="gpioColumn" prefWidth="40.66668450832367" text="GPIO" />
                     <TableColumn fx:id="numberOfLEDSconnectedColumn" prefWidth="45.6666259765625" text="LEDs #" />
                  </columns>
                </TableView>

--- a/src/main/resources/org/dpsoftware/gui/settings.fxml
+++ b/src/main/resources/org/dpsoftware/gui/settings.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.paint.*?>
 <?import javafx.scene.text.*?>
 
-<TabPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="415.0" prefWidth="400.0" tabClosingPolicy="UNAVAILABLE" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.dpsoftware.gui.SettingsController">
+<TabPane fx:id="mainTabPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="415.0" prefWidth="400.0" tabClosingPolicy="UNAVAILABLE" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.dpsoftware.gui.SettingsController">
    <Tab text="LEDs config">
       <content>
 

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,1 +1,2 @@
 version=${project.version}
+minimum_firmware_version=4.3.8

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,2 +1,1 @@
 version=${project.version}
-minimum_firmware_version=4.3.8


### PR DESCRIPTION
- **__Breaking changes__**: requires `Glow Worm Luciferin` firmware v4.4.1
- **Big improvements on frametime and latency**.
- **Light firmware users are now notified when a new version is available**.
- Doubled the default baud rate to allow **higher framerate**.
- **Reduced CPU and GPU usage**
- **Added a small benchmark**, `Firefly Luciferin` is now able to detect if your PC is grapping the screen too fast and your microcontroller can't keep up. 
- "Devices" tab under the "Settings" menu has been restructured.
- Fixed a bug that prevented `Firefly Luciferin` from updating its companion firmware while the `bias lighting` effect is on.
- Improved auto detection for connected devices.

