### PR TITLE
stream hotfix release

### DIFF
--- a/src/main/java/org/dpsoftware/gui/SettingsController.java
+++ b/src/main/java/org/dpsoftware/gui/SettingsController.java
@@ -312,7 +312,11 @@ public class SettingsController {
         scaling.setValue(currentConfig.getOsScaling() + Constants.PERCENT);
         captureMethod.setValue(Configuration.CaptureMethod.valueOf(currentConfig.getCaptureMethod()));
         gamma.setValue(String.valueOf(currentConfig.getGamma()));
-        serialPort.setValue(currentConfig.getSerialPort());
+        if (currentConfig.isMqttStream() && currentConfig.getSerialPort().equals(Constants.SERIAL_PORT_AUTO)) {
+            serialPort.setValue(FireflyLuciferin.config.getSerialPort());
+        } else {
+            serialPort.setValue(currentConfig.getSerialPort());
+        }
         numberOfThreads.setText(String.valueOf(currentConfig.getNumberOfCPUThreads()));
         aspectRatio.setValue(currentConfig.getDefaultLedMatrix());
         switch (currentConfig.getMultiMonitor()) {
@@ -936,11 +940,13 @@ public class SettingsController {
             colorPicker.setValue(Color.rgb((int)(colorPicker.getValue().getRed() * 255), (int)(colorPicker.getValue().getGreen() * 255),
                     (int)(colorPicker.getValue().getBlue() * 255), (brightness.getValue()/100)));
         }
-        if (toggleLed.isSelected()) {
+        if (toggleLed.isSelected() || !setBrightness) {
             if (currentConfig != null && currentConfig.isMqttEnable()) {
                 StateDto stateDto = new StateDto();
                 stateDto.setState(Constants.ON);
-                stateDto.setEffect(Constants.SOLID);
+                if (!(currentConfig.isMqttEnable() && FireflyLuciferin.RUNNING)) {
+                    stateDto.setEffect(Constants.SOLID);
+                }
                 ColorDto colorDto = new ColorDto();
                 colorDto.setR((int)(colorPicker.getValue().getRed() * 255));
                 colorDto.setG((int)(colorPicker.getValue().getGreen() * 255));

--- a/src/main/java/org/dpsoftware/managers/MQTTManager.java
+++ b/src/main/java/org/dpsoftware/managers/MQTTManager.java
@@ -333,6 +333,11 @@ public class MQTTManager implements MqttCallback {
             if (!(Integer.parseInt(actualObj.get(Constants.BAUD_RATE).toString()) >= 1 && Integer.parseInt(actualObj.get(Constants.BAUD_RATE).toString()) <= 7)) {
                 validBaudRate = false;
             }
+            if (FireflyLuciferin.config.isMqttStream() && (FireflyLuciferin.config.getSerialPort() == null
+                    || FireflyLuciferin.config.getSerialPort().isEmpty()
+                    || FireflyLuciferin.config.getSerialPort().equals(Constants.SERIAL_PORT_AUTO))) {
+                FireflyLuciferin.config.setSerialPort(actualObj.get(Constants.MQTT_DEVICE_NAME).textValue());
+            }
             SettingsController.deviceTableData.add(new GlowWormDevice(actualObj.get(Constants.MQTT_DEVICE_NAME).textValue(),
                     actualObj.get(Constants.STATE_IP).textValue(), actualObj.get(Constants.DEVICE_VER).textValue(),
                     (actualObj.get(Constants.DEVICE_BOARD) == null ? Constants.DASH : actualObj.get(Constants.DEVICE_BOARD).textValue()),


### PR DESCRIPTION
- **Hotfix release**: Fixed a bug that prevented some devices from receiving `Firefly Luciferin` settings when the MQTT stream is active.
  Thanks to `sashayohan` for reporting the problem and for his help in discovering the cause of the problem.
