### PR TITLE
Web interface fix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,29 +33,23 @@
 </style>
 
 ### In this release:
-- ***Breaking changes***: requires `Glow Worm Luciferin` firmware (v5.2.3). 
-- **MQTT is now optional for FULL firmware**. 
-- `Glow Worm Luciferin` FULL firmware now exposes a **Web Interface to control your lights from your browser** without the needs of the `Firefly Luciferin` PC client.   
-- `Glow Worm Luciferin` firmware can now be **controlled via standard HTTP methods** (GET/POST).  
-- Introducing **Luciferin Modules** for the **Luciferin Official PCB**.  
+- ***Breaking changes***: requires `Glow Worm Luciferin` firmware (v5.3.1).
+- **Added an option menu to the Web Interface** where you can change all firmware related settings without the needs of reflashing the microcontroller.
+- Added "Info Graphics" button. Linux only, the feature was already available in Windows.
+- Added the possibility to start and stop the Bias Light effect via Web Interface.
+- ESP8266 goes out of memory when serving Web Interface while driving many LEDs. Fixed.
+- Fixed an error that caused white temperature to reset to default after WiFi disconnection.
+- Various improvements on ESP32, updated ESP-IDF to the latest 4.3.1.
+- Arduino Bootstrapper update (v.1.11.4) memory optimizations.  
+  
+### In the previous release:
+- ***Breaking changes***: requires `Glow Worm Luciferin` firmware (v5.2.3).
+- **MQTT is now optional for FULL firmware**.
+- `Glow Worm Luciferin` FULL firmware now exposes a **Web Interface to control your lights from your browser** without the needs of the `Firefly Luciferin` PC client.
+- `Glow Worm Luciferin` firmware can now be **controlled via standard HTTP methods** (GET/POST).
+- Introducing **Luciferin Modules** for the **Luciferin Official PCB**.
 - Luciferin is now able to detect what is the monitor on your right/center/left position for an easyer configuration. **On some multi monitor configurations it may be necessary to select the monitor again.** To do it go to "Settings -> Mode tab -> Bind to display".
-- Fixed a bug that caused flickering on ESP32 when reducing the numbers of LEDs in use.  
-- Fixed a bug that caused occasional graphical glitches when right clicking the tray icon (Windows only).  
+- Fixed a bug that caused flickering on ESP32 when reducing the numbers of LEDs in use.
+- Fixed a bug that caused occasional graphical glitches when right clicking the tray icon (Windows only).
 - Upgrade to Java 17 and JavaFX 17.
 - Arduino Bootstrapper update (v.1.11.2) improves UI during the initial setup.
-
-### In the previous release:
-- ***Breaking changes***: requires `Glow Worm Luciferin` firmware (v5.1.4). WiFi enhancements/fixes refers to full firmware.
-- ***Enriched the "Info" popup*** with a graph that shows the quality of the synchronization between Firefly Luciferin PC software and the Glow Worm Luciferin firmware. Added a graph that shows the WiFi signal strength of the microcontroller in use. A good WiFi signal strength is required for reliable operation.
-- ***Added support for DHCP, no need to enter a fixed IP address anymore.***
-- ***Added WiFi signal strength info on "devices tab"***, this is useful when using multi devices.
-- ***Improved WiFi signal strength by increasing the WiFi output power to +20.5dBm.***
-- ***Fixed an heap fragmentation problem that caused severe slow down while using UDP stream.*** This problem occurs randomly after some time of screen capture.
-- MQTT username and password are now optional. (if your MQTT server does not require credentials).
-- Output Device menu now filters for valid COM ports by hiding the other ports.
-- Fixed an error that prevented the bias light effect from starting if LEDs where turned off by an external sources like Home Assistant.
-- Fixed a problem with auto update when using different MQTT topics for different devices. (thanks @pblOm)
-- Fixed a bug that prevented the automatic black bar detection algorithm from detecting the letterbox mode on big 1080P TVs. (thanks @Marc)
-- Fixed a bug that affected the Twinkle effect causing it to freeze at some point.
-- Some routers do not display ESP8266 devices in the connected devices list. Fixed.
-- Arduino Bootstrapper update (v.1.10.3).

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@
 - Added the possibility to start and stop the Bias Light effect via Web Interface.
 - ESP8266 goes out of memory when serving Web Interface while driving many LEDs. Fixed.
 - Fixed an error that caused white temperature to reset to default after WiFi disconnection.
+- Fixed an error that prevented ESP32 to start the bias light effect when using a static IP address with MQTT disabled.
 - Various improvements on ESP32, updated ESP-IDF to the latest 4.3.1.
 - Arduino Bootstrapper update (v.1.11.4) memory optimizations.  
   

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
         <project.version>2.2.6</project.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>17</java.version>
-        <java.fx.version>17.0.0.1</java.fx.version>
+        <java.version>17.0.1</java.version>
+        <java.fx.version>17.0.1</java.fx.version>
         <javafx.maven.plugin.version>0.0.6</javafx.maven.plugin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -558,8 +558,8 @@ public class Constants {
     public static final String TOOLTIP_MQTTTOPIC = "OPTIONAL: MQTT topic, change it if you want to run Luciferin on more than one computer over MQTT.";
     public static final String TOOLTIP_MQTTUSER = "OPTIONAL: MQTT username";
     public static final String TOOLTIP_MQTTPWD = "OPTIONAL: MQTT password";
-	public static final String TOOLTIP_MQTTENABLE = "Enable MQTT. Requies FULL firmware.";
-	public static final String TOOLTIP_WIFIENABLE = "Enable WiFi. Requies FULL firmware.";
+	public static final String TOOLTIP_MQTTENABLE = "Enable MQTT. Requires FULL firmware. If you enable MQTT, please be sure that MQTT is enabled on Glow Worm Firmware.";
+	public static final String TOOLTIP_WIFIENABLE = "Enable WiFi. Requires FULL firmware.";
 	public static final String TOOLTIP_EYE_CARE = "If enabled LEDs will never turn off in black scenes, a soft and gentle light is used instead.";
 	public static final String TOOLTIP_MQTTSTREAM = "This method does not require a USB cable, for best performance prefer GPIO3 or GPIO2";
 	public static final String TOOLTIP_STREAMTYPE = "UDP is the fastest one";

--- a/src/main/java/org/dpsoftware/gui/GUIManager.java
+++ b/src/main/java/org/dpsoftware/gui/GUIManager.java
@@ -451,7 +451,7 @@ public class GUIManager extends JFrame {
 
         Platform.runLater(() -> {
             try {
-                if (NativeExecutor.isWindows() && stageName.equals(Constants.FXML_INFO)) {
+                if (NativeExecutor.isLinux() && stageName.equals(Constants.FXML_INFO)) {
                     stage = new Stage();
                 }
                 Scene scene = new Scene(loadFXML(stageName));

--- a/src/main/java/org/dpsoftware/gui/GUIManager.java
+++ b/src/main/java/org/dpsoftware/gui/GUIManager.java
@@ -437,7 +437,7 @@ public class GUIManager extends JFrame {
     /**
      * Show a dialog with a framerate counter
      */
-    void showFramerateDialog() {
+    public void showFramerateDialog() {
 
         showStage(Constants.FXML_INFO);
 
@@ -451,6 +451,9 @@ public class GUIManager extends JFrame {
 
         Platform.runLater(() -> {
             try {
+                if (NativeExecutor.isWindows() && stageName.equals(Constants.FXML_INFO)) {
+                    stage = new Stage();
+                }
                 Scene scene = new Scene(loadFXML(stageName));
                 if (FireflyLuciferin.config.getTheme().equals(Constants.Theme.DARK_THEME.getTheme())) {
                     scene.getStylesheets().add(Objects.requireNonNull(getClass().getResource("css/dark-theme.css")).toExternalForm());

--- a/src/main/java/org/dpsoftware/gui/controllers/ControlTabController.java
+++ b/src/main/java/org/dpsoftware/gui/controllers/ControlTabController.java
@@ -53,6 +53,7 @@ public class ControlTabController {
     @FXML private final StringProperty producerValue = new SimpleStringProperty("");
     @FXML private final StringProperty consumerValue = new SimpleStringProperty("");
     @FXML private Button playButton;
+    @FXML public Button showInfo;
     Image controlImage;
     ImageView imageView;
     public AnimationTimer animationTimer;
@@ -159,6 +160,18 @@ public class ControlTabController {
                 FireflyLuciferin.guiManager.startCapturingThreads();
             }
         }
+
+    }
+
+    /**
+     * Show info popup on Linux
+     * @param e InputEvent
+     */
+    @FXML
+    @SuppressWarnings("unused")
+    public void onMouseClickedShowInfo(InputEvent e) {
+
+        FireflyLuciferin.guiManager.showFramerateDialog();
 
     }
 

--- a/src/main/java/org/dpsoftware/gui/controllers/InfoController.java
+++ b/src/main/java/org/dpsoftware/gui/controllers/InfoController.java
@@ -35,6 +35,7 @@ import javafx.scene.control.SplitPane;
 import javafx.stage.Stage;
 import lombok.extern.slf4j.Slf4j;
 import org.dpsoftware.FireflyLuciferin;
+import org.dpsoftware.NativeExecutor;
 import org.dpsoftware.config.Constants;
 import org.dpsoftware.utilities.CommonUtility;
 
@@ -92,6 +93,9 @@ public class InfoController {
         version.setText(Constants.INFO_VERSION.replaceAll("VERSION", FireflyLuciferin.version));
         runLater();
         startAnimationTimer();
+        if (NativeExecutor.isLinux()) {
+            splitPane.setDividerPosition(0,0.4);
+        }
 
     }
 

--- a/src/main/java/org/dpsoftware/managers/DisplayManager.java
+++ b/src/main/java/org/dpsoftware/managers/DisplayManager.java
@@ -156,7 +156,11 @@ public class DisplayManager {
      */
     public DisplayInfo getDisplayInfo(int monitorIndex) {
 
-        return getDisplayList().get(monitorIndex);
+        try {
+            return getDisplayList().get(monitorIndex);
+        } catch (Exception e) {
+            return null;
+        }
 
     }
 
@@ -202,10 +206,14 @@ public class DisplayManager {
                 displayName = Constants.SCREEN_LEFT;
             }
         }
-        if (dispInfo.getMonitorName() != null && dispInfo.getMonitorName().length() > 0) {
-            displayName = displayName.replace("{0}", dispInfo.getMonitorName());
+        if (dispInfo == null) {
+            displayName = "Screen " + monitorIndex;
         } else {
-            displayName = displayName.replace(" ({0})", "");
+            if (dispInfo.getMonitorName() != null && dispInfo.getMonitorName().length() > 0) {
+                displayName = displayName.replace("{0}", dispInfo.getMonitorName());
+            } else {
+                displayName = displayName.replace(" ({0})", "");
+            }
         }
         return displayName;
 

--- a/src/main/resources/org/dpsoftware/gui/controlTab.fxml
+++ b/src/main/resources/org/dpsoftware/gui/controlTab.fxml
@@ -59,7 +59,7 @@
                     <padding>
                         <Insets bottom="5.0" />
                     </padding>
-                    <Button fx:id="showInfo" mnemonicParsing="false" onMouseClicked="#onMouseClickedShowInfo" prefHeight="25.0" prefWidth="319.0" text="Info">
+                    <Button fx:id="showInfo" mnemonicParsing="false" onMouseClicked="#onMouseClickedShowInfo" prefHeight="25.0" prefWidth="319.0" text="Info Graphs">
                   <VBox.margin>
                      <Insets bottom="10.0" />
                   </VBox.margin></Button>

--- a/src/main/resources/org/dpsoftware/gui/controlTab.fxml
+++ b/src/main/resources/org/dpsoftware/gui/controlTab.fxml
@@ -3,9 +3,9 @@
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 
-<?import javafx.scene.text.Font?>
-<AnchorPane fx:id="controlTab" minHeight="0.0" minWidth="0.0" prefHeight="415.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.dpsoftware.gui.controllers.ControlTabController">
+<AnchorPane fx:id="controlTab" minHeight="0.0" minWidth="0.0" prefHeight="415.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/11.0.2" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.dpsoftware.gui.controllers.ControlTabController">
 
     <children>
         <GridPane prefHeight="380.0" prefWidth="400.0">
@@ -15,9 +15,9 @@
                 <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="80.0" />
             </columnConstraints>
             <rowConstraints>
-                <RowConstraints minHeight="10.0" prefHeight="20.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="10.0" prefHeight="10.0" vgrow="SOMETIMES" />
                 <RowConstraints minHeight="10.0" prefHeight="50.0" vgrow="SOMETIMES" />
-                <RowConstraints minHeight="10.0" prefHeight="20.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             </rowConstraints>
             <children>
                 <VBox nodeOrientation="RIGHT_TO_LEFT" prefHeight="200.0" prefWidth="25.0" GridPane.halignment="RIGHT" GridPane.rowIndex="2" GridPane.valignment="TOP">
@@ -59,6 +59,10 @@
                     <padding>
                         <Insets bottom="5.0" />
                     </padding>
+                    <Button fx:id="showInfo" mnemonicParsing="false" onMouseClicked="#onMouseClickedShowInfo" prefHeight="25.0" prefWidth="319.0" text="Info">
+                  <VBox.margin>
+                     <Insets bottom="10.0" />
+                  </VBox.margin></Button>
                     <children>
                         <Label fx:id="producerLabel" text="Producer">
                         </Label>

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,2 +1,2 @@
 version=${project.version}
-minimum.firmware.version=5.2.3
+minimum.firmware.version=5.3.1


### PR DESCRIPTION
- ***Breaking changes***: requires `Glow Worm Luciferin` firmware (v5.3.1).
- **Added an option menu to the [Web Interface](https://github.com/sblantipodi/firefly_luciferin/wiki/Remote-Access#luciferin-web-interface)** where you can change all firmware related settings without the needs of reflashing the microcontroller.
- Added "Info Graphics" button. Linux only, the feature was already available in Windows.
- Added the possibility to start and stop the Bias Light effect via Web Interface.
- ESP8266 goes out of memory when serving Web Interface while driving many LEDs. Fixed.
- Fixed an error that caused white temperature to reset to default after WiFi disconnection.
- Fixed an error that prevented ESP32 to start the bias light effect when using a static IP address. with MQTT disabled.
- Various improvements on ESP32, updated ESP-IDF to the latest 4.3.1.
- [Arduino Bootstrapper](https://github.com/sblantipodi/arduino_bootstrapper/releases) update (v.1.11.4) memory optimizations.