### PR TITLE
Ignore subtitles when trying to detect black borders

### DIFF
--- a/src/main/java/org/dpsoftware/grabber/ImageProcessor.java
+++ b/src/main/java/org/dpsoftware/grabber/ImageProcessor.java
@@ -341,7 +341,11 @@ public class ImageProcessor {
                 g = color.getGreen();
                 b = color.getBlue();
             }
-            if (r <= Constants.DEEP_BLACK_CHANNEL_TOLERANCE && g <= Constants.DEEP_BLACK_CHANNEL_TOLERANCE && b <= Constants.DEEP_BLACK_CHANNEL_TOLERANCE) {
+            // Ignore monochrome pixels that are not on borders, since they might be subtitles
+            boolean atBorder = offsetX < 10;
+            boolean monochrome = (r == g && g == b);
+            boolean dark = (r <= Constants.DEEP_BLACK_CHANNEL_TOLERANCE && g <= Constants.DEEP_BLACK_CHANNEL_TOLERANCE && b <= Constants.DEEP_BLACK_CHANNEL_TOLERANCE);
+            if (dark || (!atBorder && monochrome)) {
                 blackPixelMatrix[j][columnRowIndex] = 1;
             } else {
                 blackPixelMatrix[j][columnRowIndex] = 0;


### PR DESCRIPTION
In the current black border detection, any non-black pixel that's found is concluded to be part of the image. As a result, if a letterboxed film has subtitles in the bottom black area, the detected rectangle will become larger. As a result, the LEDs will flash whenever the subtitles appear or disappear, even though the scene itself isn't changing.

This commit changes the black border heuristics to ignore monochrome pixels. Since almost all subtitles are white (or anti-aliased), and almost all movies have color, this fixes the flashing for me.

However, I'm pretty sure actual monochrome movies might be negatively affected... unfortunately, I have none to test with.

Any thoughts?