### PR TITLE
Update SerialManager.java

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,11 @@
 
 ### In this release:
 
+- Hotfix release: Fixed a regression that doesn't permit to drive LEDs via USB when MQTT is enabled. **This issue
+  affects Firefly Luciferin only, there is no need to update the firmware.**
+
+### In the previous release:
+
 - ***Breaking changes***: requires `Glow Worm Luciferin` (v5.11.8)
 - **Added support for ESP32-C3, ESP32-S2, ESP32-S3.**
   Lolin ESP32-C3, Lolin ESP32-S2 and Lolin ESP32-S3 are now fully compatible with the existing Luciferin Official PCB.
@@ -47,29 +52,3 @@
 - Fixed an issue that prevented a profile from changing the current framerate without pausing and restarting the
   capture.
 - Arduino Bootstrapper update (v.1.15.2).
-
-
-### In the previous release:
-
-- ***Breaking changes***: requires `Glow Worm Luciferin` (v5.10.6).
-- **Added a smoothing feature that is used to smooth the transitions from one color to another**,
-  this is particularly useful to reduce eye strain with contents that produces fast flashing like fast peaced games or
-  similar. This setting can be controlled on the fly via MQTT/Home Assistant.
-- **Added a latency test**. This test displays colors in rapid succession and helps you check if the latency between the
-  image shown on your monitor and the color displayed on the led strip is acceptable to you. Highering the framerate
-  helps reducing the latency. You can run this test at 10 different speed. This is also useful when choosing the right
-  smoothing level for your preferences.
-- **Web Interface now displays an Auto save button**, if auto save is enabled, color and brightness information is
-  stored into memory to retain this settings after reboot.
-- Added an option within the Web Interface to choose to **turn on the LEDs once the microcontroller boots up**.
-- **Device reset** has been improved.
-- **Added support for RGB and BGR color order**.
-- **RGBW SK6812 performance boost**. +30% maximum framerate and reduced latency.
-- **Added support for the QuinLED dig2go pre-build board**.
-- Added support for **Hardware Button**.
-- Fixed an issue that prevented correct screen capture once changed the desired framerate or aspect ratio.
-- Minor UI improvements.
-- Web Installer now presents an option to install beta or previous version of the Glow Worm Luciferin firmware.
-- Improved log level configurability.
-- Removed warnings in the Home Assistant logs.
-- Arduino Bootstrapper update (v.1.14).

--- a/src/main/java/org/dpsoftware/managers/SerialManager.java
+++ b/src/main/java/org/dpsoftware/managers/SerialManager.java
@@ -314,7 +314,8 @@ public class SerialManager {
                                         validBaudrate = false;
                                     }
                                     glowWormDevice.setBaudRate(validBaudrate ? Enums.BaudRate.findByValue(receivedBaudrate).getBaudRate() : Constants.DASH);
-                                } else if ((!config.isFullFirmware() || !config.isMqttEnable()) && inputLine.contains(Constants.SERIAL_FRAMERATE)) {
+                                } else if ((!MainSingleton.getInstance().config.isFullFirmware() || !MainSingleton.getInstance().config.isMqttEnable()
+                                        || !MainSingleton.getInstance().config.isWirelessStream()) && inputLine.contains(Constants.SERIAL_FRAMERATE)) {
                                     FireflyLuciferin.FPS_GW_CONSUMER = Float.parseFloat(inputLine.replace(Constants.SERIAL_FRAMERATE, ""));
                                 } else if (inputLine.contains(Constants.SERIAL_LDR)) {
                                     CommonUtility.ldrStrength = Integer.parseInt(inputLine.replace(Constants.SERIAL_LDR, ""));

--- a/src/main/java/org/dpsoftware/managers/SerialManager.java
+++ b/src/main/java/org/dpsoftware/managers/SerialManager.java
@@ -314,8 +314,7 @@ public class SerialManager {
                                         validBaudrate = false;
                                     }
                                     glowWormDevice.setBaudRate(validBaudrate ? Enums.BaudRate.findByValue(receivedBaudrate).getBaudRate() : Constants.DASH);
-                                } else if ((!MainSingleton.getInstance().config.isFullFirmware() || !MainSingleton.getInstance().config.isMqttEnable()
-                                        || !MainSingleton.getInstance().config.isWirelessStream()) && inputLine.contains(Constants.SERIAL_FRAMERATE)) {
+                                } else if ((!config.isFullFirmware() || !config.isMqttEnable() || !config.isWirelessStream()) && inputLine.contains(Constants.SERIAL_FRAMERATE)) {
                                     FireflyLuciferin.FPS_GW_CONSUMER = Float.parseFloat(inputLine.replace(Constants.SERIAL_FRAMERATE, ""));
                                 } else if (inputLine.contains(Constants.SERIAL_LDR)) {
                                     CommonUtility.ldrStrength = Integer.parseInt(inputLine.replace(Constants.SERIAL_LDR, ""));

--- a/src/main/java/org/dpsoftware/utilities/CommonUtility.java
+++ b/src/main/java/org/dpsoftware/utilities/CommonUtility.java
@@ -503,7 +503,9 @@ public class CommonUtility {
                         CommonUtility.ldrStrength = fpsTopicMsg.get(Constants.MQTT_LDR_VALUE) != null ? fpsTopicMsg.get(Constants.MQTT_LDR_VALUE).asInt() : 0;
                     }
                     if (glowWormDevice.getDeviceName().equals(FireflyLuciferin.config.getOutputDevice()) || glowWormDevice.getDeviceIP().equals(FireflyLuciferin.config.getOutputDevice())) {
-                        FireflyLuciferin.FPS_GW_CONSUMER = Float.parseFloat(fpsTopicMsg.get(Constants.MQTT_TOPIC_FRAMERATE).asText());
+                        if (FireflyLuciferin.config.isWirelessStream()) {
+                            FireflyLuciferin.FPS_GW_CONSUMER = Float.parseFloat(fpsTopicMsg.get(Constants.MQTT_TOPIC_FRAMERATE).asText());
+                        }
                         CommonUtility.wifiStrength = fpsTopicMsg.get(Constants.WIFI) != null ? fpsTopicMsg.get(Constants.WIFI).asInt() : 0;
                     }
                 }


### PR DESCRIPTION
- Hotfix release: Fixed a regression that doesn't permit to drive LEDs via USB when MQTT is enabled. **This issue affects Firefly Luciferin only, there is no need to update the firmware.**