### PR TITLE
Don't return negative border size

### DIFF
--- a/src/main/java/org/dpsoftware/grabber/ImageProcessor.java
+++ b/src/main/java/org/dpsoftware/grabber/ImageProcessor.java
@@ -351,9 +351,9 @@ public class ImageProcessor {
      */
     public static int calculateBorders(Enums.AspectRatio aspectRatio) {
         if (aspectRatio == Enums.AspectRatio.LETTERBOX) {
-            return (((FireflyLuciferin.config.getScreenResY() * Constants.AR_LETTERBOX_GAP) / 2160) / Constants.RESAMPLING_FACTOR) - 5;
+            return Math.max(0, (((FireflyLuciferin.config.getScreenResY() * Constants.AR_LETTERBOX_GAP) / 2160) / Constants.RESAMPLING_FACTOR) - 5);
         } else {
-            return (((FireflyLuciferin.config.getScreenResY() * Constants.AR_PILLARBOX_GAP) / 2160) / Constants.RESAMPLING_FACTOR) - 5;
+            return Math.max(0, (((FireflyLuciferin.config.getScreenResY() * Constants.AR_PILLARBOX_GAP) / 2160) / Constants.RESAMPLING_FACTOR) - 5);
         }
     }
 


### PR DESCRIPTION
The magic numbers in this calculation return a negative border size when running at 1280x720 resolution. Let's return at least 0 for all cases, while a more appropriate calculation is derived.

Fixes #147.