### PR TITLE
Fix german translation

### DIFF
--- a/src/main/resources/messagebundle_de.properties
+++ b/src/main/resources/messagebundle_de.properties
@@ -1,6 +1,6 @@
 fxml.save.and.close=Speichern und schließen
 fxml.save=Speichern
-fxml.reset=Képernyő visszaállítása
+fxml.reset=Bildschirm zurücksetzen
 fxml.setting.controls=Steuerung
 fxml.setting.ledsconfig=LED Konfiguration
 fxml.setting.mode=Modus


### PR DESCRIPTION
The "reset screen" button was wrongly translated in german.
Now it shows really some german text telling "reset screen".