### PR TITLE
Properly handle expired restore token on Wayland

### DIFF
--- a/src/main/java/org/dpsoftware/managers/PipelineManager.java
+++ b/src/main/java/org/dpsoftware/managers/PipelineManager.java
@@ -141,11 +141,18 @@ public class PipelineManager {
                 showChooseDisplayAlert();
                 alertShown.set(true);
             }
-            screenCastIface.Start(receivedSessionHandle, "", Collections.emptyMap());
-            CommonUtility.sleepMilliseconds(200);
-            if (NativeExecutor.isWayland() && restoreTokenMatch.get() == false && alertShown.get() == false) {
-                showChooseDisplayAlert();
+            try {
+                screenCastIface.Start(receivedSessionHandle, "", Collections.emptyMap());
+            } catch (org.freedesktop.dbus.exceptions.DBusExecutionException e) {
+                if (NativeExecutor.isWayland() && alertShown.get() == false) {
+                    log.info("Screen cast restore token is invalid or expired. Requesting a new one.");
+                    showChooseDisplayAlert();
+                    screenCastIface.Start(receivedSessionHandle, "", Collections.emptyMap());
+                } else {
+                    throw e;
+                }
             }
+            CommonUtility.sleepMilliseconds(200);
             var c = streamIdMaybe.thenApply(streamId -> {
                 FileDescriptor fileDescriptor = screenCastIface.OpenPipeWireRemote(receivedSessionHandle, Collections.emptyMap()); // block until stream started before calling OpenPipeWireRemote
                 return new XdgStreamDetails(streamId, fileDescriptor);


### PR DESCRIPTION
The previous version just gets crashes on an exception from invalid restore token and doesn't request a new valid one.

This version catches the exception and starts the screen cast with a new token.

I'm not sure what the purpose of the 200 ms sleep is, so I left it similar to the previous version.