### PR TITLE
Logging improvements

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <conversionRule conversionWord="instanceNumber"
                     converterClass="org.dpsoftware.config.InstanceConverter" />
 


### PR DESCRIPTION
The first commit disables a huge number of completely useless logging messages about the logging library itself.

The second commit is a bit opionated, but I really don't want this application to log to a file by default. At the very least the log path should be something more appropriate (e.g. $XDG_DATA_HOME).