### PR TITLE
Get command path dynamically for restarting

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module org.dpsoftware {
     requires ch.qos.logback.classic;
     requires org.freedesktop.dbus;
     requires jdk.incubator.vector;
+    requires java.management;
 
     opens org.dpsoftware to javafx.fxml, javafx.web;
     opens org.dpsoftware.gui to javafx.fxml, javafx.web;

--- a/src/main/java/org/dpsoftware/NativeExecutor.java
+++ b/src/main/java/org/dpsoftware/NativeExecutor.java
@@ -38,8 +38,10 @@ import org.dpsoftware.utilities.CommonUtility;
 
 import java.awt.*;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
 import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -169,9 +171,15 @@ public final class NativeExecutor {
             execCommand.addAll(Arrays.stream(Constants.FLATPAK_RUN).toList());
         } else if (NativeExecutor.isSnap()) {
             execCommand.addAll(Arrays.stream(Constants.SNAP_RUN).toList());
+        } else if (System.getProperty(Constants.JPACKAGE_APP_PATH) != null) {
+            execCommand.add(System.getProperty(Constants.JPACKAGE_APP_PATH));
         } else {
-            execCommand.add(getInstallationPath());
+            execCommand.add(System.getProperty(Constants.JAVA_HOME) + Constants.JAVA_BIN);
+            execCommand.addAll(ManagementFactory.getRuntimeMXBean().getInputArguments());
+            execCommand.add(Constants.JAR_PARAM);
+            execCommand.add(System.getProperty(Constants.JAVA_COMMAND).split("\\s+")[0]);
         }
+
         if (NativeExecutor.isRunningOnSandbox()) {
             execCommand.add(Constants.RESTART_DELAY);
         }

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -712,5 +712,9 @@ public class Constants {
     public static final ArrayList<String> HTTP_TOPIC_TO_SKIP_FOR_SATELLITES = new ArrayList<>(Arrays
             .asList(TOPIC_GLOW_WORM_FIRM_CONFIG, HTTP_SETTING, HTTP_SET_LDR));
     public static int GROUP_BY_LEDS = 1;
-
+    public static final String JPACKAGE_APP_PATH = "jpackage.app-path";
+    public static final String JAVA_HOME = "java.home";
+    public static final String JAVA_COMMAND = "sun.java.command";
+    public static final String JAVA_BIN = "/bin/java";
+    public static final String JAR_PARAM = "-jar";
 }


### PR DESCRIPTION
The previous version assumes certain installation location. This version works regardless of where the jar file was installed or if it's just a development build that wasn't really installed at all.

I didn't remove the previously used `getInstallationPath()` as it's also used to Windows-specific `writeRegistryKey()`.