### PR TITLE
Fix "Sources not selected" crash on Wayland

### DIFF
--- a/src/main/java/org/dpsoftware/managers/PipelineManager.java
+++ b/src/main/java/org/dpsoftware/managers/PipelineManager.java
@@ -159,7 +159,7 @@ public class PipelineManager {
             }).get();
             return c;
         } catch (Exception e) {
-            log.error(e.getMessage());
+            log.error(e.getMessage(), e);
         }
         return null;
     }

--- a/src/main/java/org/dpsoftware/managers/PipelineManager.java
+++ b/src/main/java/org/dpsoftware/managers/PipelineManager.java
@@ -160,18 +160,8 @@ public class PipelineManager {
                 alertShown.set(true);
             }
 
-            try {
-                screenCastIface.Start(receivedSessionHandle, "", Collections.emptyMap());
-            } catch (org.freedesktop.dbus.exceptions.DBusExecutionException e) {
-                if (NativeExecutor.isWayland() && alertShown.get() == false) {
-                    log.info("Screen cast restore token is invalid or expired. Requesting a new one.");
-                    showChooseDisplayAlert();
-                    screenCastIface.Start(receivedSessionHandle, "", Collections.emptyMap());
-                } else {
-                    throw e;
-                }
-            }
-            CommonUtility.sleepMilliseconds(200);
+            screenCastIface.Start(receivedSessionHandle, "", Collections.emptyMap());
+
             var c = streamIdMaybe.thenApply(streamId -> {
                 FileDescriptor fileDescriptor = screenCastIface.OpenPipeWireRemote(receivedSessionHandle, Collections.emptyMap()); // block until stream started before calling OpenPipeWireRemote
                 return new XdgStreamDetails(streamId, fileDescriptor);


### PR DESCRIPTION
The first two commits are not directly fixing anything, it's just to make it easier to fix and troubleshoot similar issues. Then there is a commit that adds proper synchronization for waiting the source selection to be ready.

~~The second commit is a workaround fixing the crash on Wayland in the case where the screen capture permission pop-up would be shown previously. I guess the pop-up caused a delay in the app that acted as a similar workaround before.~~ EDIT: I removed this workaround and added a proper fix.

The crash looked like this:

```
[Instance #1] 11:55:29.490 [JavaFX Application Thread] ERROR o.d.managers.PipelineManager - Sources not selected
org.freedesktop.dbus.exceptions.DBusExecutionException: Sources not selected
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:501)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:485)
	at org.freedesktop.dbus.messages.Error.getException(Error.java:113)
	at org.freedesktop.dbus.messages.Error.throwException(Error.java:138)
	at org.freedesktop.dbus.RemoteInvocationHandler.executeRemoteMethod(RemoteInvocationHandler.java:238)
	at org.freedesktop.dbus.RemoteInvocationHandler.executeRemoteMethod(RemoteInvocationHandler.java:251)
	at org.freedesktop.dbus.RemoteInvocationHandler.executeRemoteMethod(RemoteInvocationHandler.java:153)
	at org.freedesktop.dbus.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:97)
	at jdk.proxy2/jdk.proxy2.$Proxy14.Start(Unknown Source)
	at org.dpsoftware.managers.PipelineManager.getXdgStreamDetails(PipelineManager.java:146)
	at org.dpsoftware.managers.PipelineManager.getLinuxPipelineParams(PipelineManager.java:195)
	at org.dpsoftware.grabber.GrabberManager.launchAdvancedGrabber(GrabberManager.java:108)
	at org.dpsoftware.FireflyLuciferin.launchGrabberAndConsumers(FireflyLuciferin.java:329)
	at org.dpsoftware.FireflyLuciferin.start(FireflyLuciferin.java:286)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$9(LauncherImpl.java:839)
	at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$12(PlatformImpl.java:483)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:456)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:455)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$10(GtkApplication.java:264)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Exception in Application start method
Exception in thread "main" java.lang.RuntimeException: Exception in Application start method
	at com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:893)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication$2(LauncherImpl.java:196)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.AssertionError
	at org.dpsoftware.managers.PipelineManager.getLinuxPipelineParams(PipelineManager.java:196)
	at org.dpsoftware.grabber.GrabberManager.launchAdvancedGrabber(GrabberManager.java:108)
	at org.dpsoftware.FireflyLuciferin.launchGrabberAndConsumers(FireflyLuciferin.java:329)
	at org.dpsoftware.FireflyLuciferin.start(FireflyLuciferin.java:286)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$9(LauncherImpl.java:839)
	at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$12(PlatformImpl.java:483)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:456)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:455)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$10(GtkApplication.java:264)
	... 1 more
```