### PR TITLE
Reverted to Java 24 due to compatibility issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
           echo $RELEASE_VERSION
           echo ${{ env.RELEASE_VERSION }}
         shell: bash
-      - name: Set up AdoptOpenJDK 25
+      - name: Set up AdoptOpenJDK 24
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '25'
+          java-version: '24'
           architecture: x64
       - name: Install submodules
         run: |
@@ -81,11 +81,11 @@ jobs:
         run: |
           echo $RELEASE_VERSION
           echo ${{ env.RELEASE_VERSION }}
-      - name: Set up AdoptOpenJDK 25
+      - name: Set up AdoptOpenJDK 24
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '25'
+          java-version: '24'
           architecture: x64
       - id: get-id
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '25'
+          java-version: '24'
           architecture: x64
       - name: Install submodules
         run: |
@@ -109,7 +109,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '25'
+          java-version: '24'
           architecture: x64
       - id: get-id
         run: |
@@ -174,7 +174,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '25'
+          java-version: '24'
           architecture: x64
       - name: Set up Maven Settings for deploy
         uses: s4u/maven-settings-action@v4.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.fx.version>25</java.fx.version>
         <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>24</maven.compiler.source>
+        <maven.compiler.target>24</maven.compiler.target>
         <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
         <maven.assembly.version>3.7.1</maven.assembly.version>
         <maven.shade.version>3.6.0</maven.shade.version>

--- a/src/main/resources/build_assets/org.dpsoftware.FireflyLuciferin.appdata.xml
+++ b/src/main/resources/build_assets/org.dpsoftware.FireflyLuciferin.appdata.xml
@@ -72,18 +72,14 @@
         </screenshot>
     </screenshots>
     <releases>
-        <release version="2.23.10" date="2025-08-18">
-            <url type="details">https://github.com/sblantipodi/firefly_luciferin/releases/tag/v2.23.9</url>
+        <release version="2.24.5" date="2025-10-21">
+            <url type="details">https://github.com/sblantipodi/firefly_luciferin/releases/tag/v2.24.5</url>
             <description>
-                <p>Hotfix release: This issue only affects Firefly Luciferin; there is no need to update the firmware.</p>
-                <p>Luciferin restarted after seemingly random periods of time. Fixed.</p>
-                <p>Reduced latency in screen capture on Linux Wayland.</p>
-                <p>Prevented invalid values from being entered during the single-device multi-monitor setup
-                    configuration.
+                <p>Hotfix release: This issue affects only Firefly Luciferin; no firmware update is required.</p>
+                <p>The application has been reverted to Java 24 due to compatibility issues: Project cannot build on
+                    Linux with Java 25. Some users experienced startup crashes on Windows caused by permission issues
+                    with temporary native files.
                 </p>
-                <p>Fixed an issue that caused incorrect colors when using the smoothing effect on Linux Wayland.</p>
-                <p>Fixed an issue where settings could not be opened on Flatpak when an update was available.</p>
-                <p>Full changelog on GitHub.</p>
             </description>
         </release>
 


### PR DESCRIPTION
- ***Hotfix release: This issue affects only Firefly Luciferin; no firmware update is required.***
- Reverted to Java 24 due to compatibility issues:
  - Some users experienced startup crashes on Windows caused by permission issues with temporary native files. Closes [#354](https://github.com/sblantipodi/firefly_luciferin/issues/354).
  - Project cannot build on Linux with Java 25 from Temurin.
 
