### PR TITLE
PR may 2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   windows_build_parallel:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   windows_build_parallel:
-    runs-on: windows-2025-vs2026
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,33 @@ a {
 
 ### In this release
 
+##### If you want to say thank you, you can do it for free by logging into GitHub, <br> clicking [Follow](https://github.com/sblantipodi), and giving a star to both the [Firefly Luciferin](https://github.com/sblantipodi/firefly_luciferin) and [Glow Worm Luciferin](https://github.com/sblantipodi/glow_worm_luciferin) repositories.
+
+- ***Update Requirement:*** This release requires `Glow Worm Luciferin` firmware **v5.25.3**.
+- **Enabled all LED configuration options
+  for [multi‑monitor setups](https://github.com/sblantipodi/firefly_luciferin/wiki/Multi-monitor-support).**
+  Closes [#417](https://github.com/sblantipodi/firefly_luciferin/issues/417).
+- Due to recent Windows
+  changes, [installing or updating software](https://github.com/sblantipodi/firefly_luciferin/wiki/Luciferin-update-management)
+  now requires administrator privileges. Firefly Luciferin no longer needs to be launched in admin mode; it will request
+  elevation only when required during the auto‑update process.
+- Improved [device discovery](https://github.com/sblantipodi/firefly_luciferin/wiki/Static-IP-and-auto-discovery) when
+  using subnets/VLANs. Device discovery across different networks no longer relies solely on UDP unicast but now uses a
+  TCP fallback, improving discoverability on certain routers.
+- Fixed DSCP/Traffic Class handling for UDP sockets. Ensured correct IPv4 TOS byte encoding to maintain compatibility
+  with recent Windows networking stack changes.
+  Closes [#419](https://github.com/sblantipodi/firefly_luciferin/issues/419).
+- Fixed race conditions on UDP ports that occurred when using the multi‑monitor configuration with a single device.
+- Fixed an issue preventing firmware auto‑update on ESP32‑C3 devices.
+- Fixed a crash occurring when
+  enabling [EMA smoothing technique](https://github.com/sblantipodi/firefly_luciferin/wiki/Smoothing-color-transitions).
+  Closes [#416](https://github.com/sblantipodi/firefly_luciferin/issues/416).
+- Fixed a crash that occurred when changing the configured LED count on the fly during UDP streaming while using a
+  device with a Static IP.
+- The tray icon tooltip did not display the device’s IP address when using multiple monitors. Fixed.
+
+### In the previous release:
+
 - **NOTE: Due to a recent Windows security update, Windows users will need to run Luciferin with administrator
   privileges to complete the automatic update. If you launched Luciferin normally, close it, restart it as
   administrator, and repeat the update process.**
@@ -58,8 +85,7 @@ a {
 
 Users running a previous version of Luciferin can upgrade using the [automatic update feature](https://github.com/sblantipodi/firefly_luciferin/wiki/Luciferin-update-management), available for both the PC software and the firmware.
 
-
-### In the previous release:
+### Two Versions Ago:
 
 - ***Update requirement***: requires `Glow Worm Luciferin` firmware (v5.23.6)
 - **Manual LED Layout Configuration:** In addition to the automatic LED layout setup, you can
@@ -117,24 +143,5 @@ Users running a previous version of Luciferin can upgrade using the [automatic u
 As always, users running a previous version of Luciferin can use
 the [automatic update feature](https://github.com/sblantipodi/firefly_luciferin/wiki/Luciferin-update-management) for
 both the PC software and the firmware.
-
-### Two Versions Ago:
-
-- ***Hotfix release: This issue affects only Firefly Luciferin; no firmware update is required.***
-- **Added a setting to adjust screen capture quality.** Balanced is recommended for most users, while higher quality
-  offers more precision at the cost of higher resource usage, and lower quality reduces the load on the system. This is
-  particularly useful on lower-end hardware or
-  in [multi-screen](https://github.com/sblantipodi/firefly_luciferin/wiki/Multi-monitor-support#screen-capture-quality)
-  setups with high resolutions.
-- **Installation improvements** (Windows only – not required on Linux):
-    - Added a checkbox option to launch Firefly Luciferin immediately
-      after [installation](https://github.com/sblantipodi/firefly_luciferin/wiki/Installers-and-binaries).
-    - Enhanced
-      the [auto-update process](https://github.com/sblantipodi/firefly_luciferin/wiki/Luciferin-update-management): no
-      manual confirmation is needed in the UI anymore, and the app now starts
-    automatically once the update is complete. This will take effect starting with the next update.
-- Fixed a Linux-only issue that prevented Firefly Luciferin from running when multiple installation types were present
-  on the system, such as .deb/.rpm, Snap, or Flatpak.
-- Java/JavaFX 25, libs update, code refactor to avoid using deprecated methods, CI/CD pipeline improvements.
 
 [Click here for the complete changelog of previous versions.](https://github.com/sblantipodi/firefly_luciferin/releases)

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -577,14 +577,15 @@ public class FireflyLuciferin extends Application {
             Color[] colorArray = MainSingleton.getInstance().sharedQueue.take();
             if (isWayland) MainSingleton.getInstance().lastLedColor = colorArray;
             if (MainSingleton.getInstance().RUNNING) {
-                if (CommonUtility.isSingleDeviceMultiScreen()) {
-                    if (colorArray.length == NetworkSingleton.getInstance().totalLedNum) {
-                        NetworkSingleton.getInstance().orderArray(colorArray);
-                        sendColors(colorArray);
-                    }
-                } else if (colorArray.length == MainSingleton.getInstance().ledNumber) {
+                // TODO
+//                if (CommonUtility.isSingleDeviceMultiScreen()) {
+//                    if (colorArray.length == NetworkSingleton.getInstance().totalLedNum) {
+//                        NetworkSingleton.getInstance().orderArray(colorArray);
+//                        sendColors(colorArray);
+//                    }
+//                } else if (colorArray.length == MainSingleton.getInstance().ledNumber) {
                     sendColors(colorArray);
-                }
+//                }
             }
         }
     }

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -285,14 +285,13 @@ public class FireflyLuciferin extends Application {
         grabberManager.getFPS();
         grabberManager.pingDevice();
         imageProcessor.calculateBorders();
+        // If multi monitor, first instance, single device, start message server before grabbers produce frames.
+        if (CommonUtility.isSingleDeviceMainInstance()) {
+            NetworkSingleton.getInstance().messageServer.startMessageServer();
+        }
         // If this instance spawns new instances, don't launch grabbers here.
         if (!(MainSingleton.getInstance().spawnInstances && MainSingleton.getInstance().config.getMultiMonitor() > 1)) {
             launchGrabberAndConsumers();
-        }
-        // If multi monitor, first instance, single instance, start message server
-        if (CommonUtility.isSingleDeviceMainInstance()) {
-            MessageServer messageServer = new MessageServer();
-            messageServer.startMessageServer();
         }
         if (CommonUtility.isSingleDeviceOtherInstance()) {
             MessageClient.getSingleInstanceMultiScreenStatus();

--- a/src/main/java/org/dpsoftware/FireflyLuciferin.java
+++ b/src/main/java/org/dpsoftware/FireflyLuciferin.java
@@ -572,19 +572,30 @@ public class FireflyLuciferin extends Application {
     @SuppressWarnings("InfiniteLoopStatement")
     void consume() throws InterruptedException, IOException {
         boolean isWayland = NativeExecutor.isWayland();
+        boolean multiMonitorLedStripOrdering = false;
         while (true) {
             Color[] colorArray = MainSingleton.getInstance().sharedQueue.take();
             if (isWayland) MainSingleton.getInstance().lastLedColor = colorArray;
             if (MainSingleton.getInstance().RUNNING) {
-                // TODO
-//                if (CommonUtility.isSingleDeviceMultiScreen()) {
-//                    if (colorArray.length == NetworkSingleton.getInstance().totalLedNum) {
-//                        NetworkSingleton.getInstance().orderArray(colorArray);
-//                        sendColors(colorArray);
-//                    }
-//                } else if (colorArray.length == MainSingleton.getInstance().ledNumber) {
+                if (CommonUtility.isSingleDeviceMultiScreen()) {
+                    if (colorArray.length == NetworkSingleton.getInstance().totalLedNum) {
+                        if (NetworkSingleton.getInstance().isLedOrderRequired()) {
+                            if (!multiMonitorLedStripOrdering) {
+                                multiMonitorLedStripOrdering = true;
+                                log.info("Using custom ordering");
+                            }
+                            NetworkSingleton.getInstance().orderArray(colorArray);
+                        } else {
+                            if (multiMonitorLedStripOrdering) {
+                                multiMonitorLedStripOrdering = false;
+                                log.info("Using normal ordering");
+                            }
+                        }
+                        sendColors(colorArray);
+                    }
+                } else if (colorArray.length == MainSingleton.getInstance().ledNumber) {
                     sendColors(colorArray);
-//                }
+                }
             }
         }
     }

--- a/src/main/java/org/dpsoftware/NativeExecutor.java
+++ b/src/main/java/org/dpsoftware/NativeExecutor.java
@@ -163,7 +163,8 @@ public final class NativeExecutor {
                     NativeExecutor.spawnNewInstance(2);
                 }
             }
-            NativeExecutor.exit();
+            // We don't use NativeExecutor.exit() here because we need to avoid race conditions
+            System.exit(0);
         }
     }
 

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -225,7 +225,6 @@ public class Constants {
     public static final String TOPIC_SET_EMA = "lights/firelyluciferin/smoothing/set";
     public static final String TOPIC_SET_FG = "lights/firelyluciferin/framgen/set";
     public static final String HTTP_SET_LDR = "ldr";
-    // TODO remove or not
     public static final String HTTP_SET_IP = "setip";
     public static final String STATE_IP = "IP";
     public static final String STATE_DHCP = "dhcp";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -650,6 +650,7 @@ public class Constants {
     public static final String ACTION = "action";
     public static final String CLIENT_ACTION = "clientActionSetState";
     // UDP
+    public static final long UDP_RECONNECT_DELAY_MS = 2000;
     public static final int UDP_PORT = 4210;
     public static final int UDP_BROADCAST_PORT = 5001;
     public static final int UDP_BROADCAST_PORT_2 = 5002;

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -661,7 +661,7 @@ public class Constants {
     public static final String UDP_DEVICE_NAME = "DN";
     public static final String UDP_DEVICE_NAME_STATIC = "DNStatic";
     public static final String UDP_PONG = "PONG";
-    public static final int DEFAULT_UDP_TRAFFIC_CLASS = 0x2E;
+    public static final int DEFAULT_UDP_TRAFFIC_CLASS = 184;
     public static final double UDP_CHUNK_SIZE = 140;
     public static final int UDP_MAX_BUFFER_SIZE = 4096;
     public static final int UDP_MICROCONTROLLER_REST_TIME = 0;

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -225,6 +225,8 @@ public class Constants {
     public static final String TOPIC_SET_EMA = "lights/firelyluciferin/smoothing/set";
     public static final String TOPIC_SET_FG = "lights/firelyluciferin/framgen/set";
     public static final String HTTP_SET_LDR = "ldr";
+    // TODO remove or not
+    public static final String HTTP_SET_IP = "setip";
     public static final String STATE_IP = "IP";
     public static final String STATE_DHCP = "dhcp";
     public static final String OTA_PWD = "XXX";

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -792,6 +792,7 @@ public class Constants {
     public static final String[] CMD_CUDA_CHECK = {"/bin/sh", "-c", "gst-inspect-1.0 nvcodec | grep cuda"};
     public static final String[] PING_WINDOWS = {"ping", "-n", "1"};
     public static final String[] PING_LINUX = {"ping", "-c", "1"};
+    public static final String[] CURL_HEAD_LINUX = {"curl", "-I", "--max-time", "4"};
     public static final String[] CUDA_REQUIRED_PLUGINS = {"cudaupload", "cudascale", "cudaconvert", "cudadownload"};
     public static final String OBJPATH_KDE_NIGHTLIGHT = "/org/kde/KWin/NightLight";
     public static final String PROP_KDE_NIGHTLIGHT = "enabled";

--- a/src/main/java/org/dpsoftware/config/Enums.java
+++ b/src/main/java/org/dpsoftware/config/Enums.java
@@ -41,6 +41,7 @@ public class Enums {
     public enum SupportedDevice {
         ESP8266,
         ESP32,
+        ESP32_C3,
         ESP32_C3_CDC,
         ESP32_C5,
         ESP32_C6,

--- a/src/main/java/org/dpsoftware/grabber/GrabberManager.java
+++ b/src/main/java/org/dpsoftware/grabber/GrabberManager.java
@@ -59,6 +59,7 @@ public class GrabberManager {
 
     public Bin bin;
     GStreamerGrabber vc;
+    private boolean linuxPingUnavailable = false;
 
     /**
      * Get suggested framerate
@@ -296,9 +297,20 @@ public class GrabberManager {
             Runnable framerateTask = () -> {
                 if (CommonUtility.getDeviceToUse() != null && CommonUtility.getDeviceToUse().getDeviceIP() != null
                         && NetworkManager.isValidIp(CommonUtility.getDeviceToUse().getDeviceIP())) {
-                    List<String> pingCmd = new ArrayList<>(Arrays.stream(NativeExecutor.isWindows() ? Constants.PING_WINDOWS : Constants.PING_LINUX).toList());
-                    pingCmd.add(CommonUtility.getDeviceToUse().getDeviceIP());
-                    NativeExecutor.runNative(pingCmd.toArray(String[]::new), 4000);
+                    String deviceIp = CommonUtility.getDeviceToUse().getDeviceIP();
+                    if (NativeExecutor.isWindows() || !linuxPingUnavailable) {
+                        List<String> pingCmd = new ArrayList<>(Arrays.stream(NativeExecutor.isWindows() ? Constants.PING_WINDOWS : Constants.PING_LINUX).toList());
+                        pingCmd.add(deviceIp);
+                        List<String> pingResult = NativeExecutor.runNative(pingCmd.toArray(String[]::new), 4000);
+                        if (NativeExecutor.isWindows() || !pingResult.isEmpty()) {
+                            return;
+                        }
+                        linuxPingUnavailable = true;
+                        log.debug("Linux ping command not available, using curl HEAD fallback.");
+                    }
+                    List<String> curlCmd = new ArrayList<>(Arrays.stream(Constants.CURL_HEAD_LINUX).toList());
+                    curlCmd.add(Constants.HTTP + deviceIp);
+                    NativeExecutor.runNative(curlCmd.toArray(String[]::new), 4000);
                 }
             };
             scheduledExecutorService.scheduleAtFixedRate(framerateTask, 0, 5, TimeUnit.SECONDS);

--- a/src/main/java/org/dpsoftware/grabber/GrabberManager.java
+++ b/src/main/java/org/dpsoftware/grabber/GrabberManager.java
@@ -118,7 +118,7 @@ public class GrabberManager {
                 if (GrabberSingleton.getInstance().pipe == null || !GrabberSingleton.getInstance().pipe.isPlaying() || pipelineRetry.get() >= 2) {
                     if (GrabberSingleton.getInstance().pipe != null) {
                         log.info("Restarting pipeline");
-                        disposePipeline(true);
+                        GrabberSingleton.getInstance().pipe.stop();
                         restartCounter.getAndIncrement();
                         if (restartCounter.get() >= Constants.MAX_PIPELINE_RESTARTS) {
                             log.error("Pipeline restarted too many times, restarting...");
@@ -127,24 +127,24 @@ public class GrabberManager {
                     } else {
                         log.info("Starting a new pipeline");
                         restartCounter.set(0);
-                    }
-                    GrabberSingleton.getInstance().pipe = new Pipeline();
-                    if (NativeExecutor.isWindows()) {
-                        DisplayManager displayManager = new DisplayManager();
-                        String monitorNativePeer = String.valueOf(displayManager.getDisplayInfo(MainSingleton.getInstance().config.getMonitorNumber()).getNativePeer());
-                        if (MainSingleton.getInstance().config.getCaptureMethod().equals(Configuration.CaptureMethod.DDUPL_DX11.name())) {
-                            bin = Gst.parseBinFromDescription(Constants.GSTREAMER_PIPELINE_WINDOWS_HARDWARE_HANDLE_DX11.replace("{0}", monitorNativePeer), true);
+                        GrabberSingleton.getInstance().pipe = new Pipeline();
+                        if (NativeExecutor.isWindows()) {
+                            DisplayManager displayManager = new DisplayManager();
+                            String monitorNativePeer = String.valueOf(displayManager.getDisplayInfo(MainSingleton.getInstance().config.getMonitorNumber()).getNativePeer());
+                            if (MainSingleton.getInstance().config.getCaptureMethod().equals(Configuration.CaptureMethod.DDUPL_DX11.name())) {
+                                bin = Gst.parseBinFromDescription(Constants.GSTREAMER_PIPELINE_WINDOWS_HARDWARE_HANDLE_DX11.replace("{0}", monitorNativePeer), true);
+                            } else {
+                                bin = Gst.parseBinFromDescription(Constants.GSTREAMER_PIPELINE_WINDOWS_HARDWARE_HANDLE_DX12.replace("{0}", monitorNativePeer), true);
+                            }
+                        } else if (NativeExecutor.isLinux()) {
+                            int keepAliveTime = Math.max(1, (1000 / GStreamerGrabber.getTargetFramerate()) / 2);
+                            String runtimeParams = finalLinuxParams
+                                    .replace(Constants.PIPEWIRE_KEEPALIVE, String.valueOf(keepAliveTime))
+                                    .replace(Constants.FPS_PLACEHOLDER, String.valueOf(GStreamerGrabber.getTargetFramerate()));
+                            bin = Gst.parseBinFromDescription(runtimeParams, true);
                         } else {
-                            bin = Gst.parseBinFromDescription(Constants.GSTREAMER_PIPELINE_WINDOWS_HARDWARE_HANDLE_DX12.replace("{0}", monitorNativePeer), true);
+                            bin = Gst.parseBinFromDescription(Constants.GSTREAMER_PIPELINE_MAC, true);
                         }
-                    } else if (NativeExecutor.isLinux()) {
-                        int keepAliveTime = Math.max(1, (1000 / GStreamerGrabber.getTargetFramerate()) / 2);
-                        String runtimeParams = finalLinuxParams
-                                .replace(Constants.PIPEWIRE_KEEPALIVE, String.valueOf(keepAliveTime))
-                                .replace(Constants.FPS_PLACEHOLDER, String.valueOf(GStreamerGrabber.getTargetFramerate()));
-                        bin = Gst.parseBinFromDescription(runtimeParams, true);
-                    } else {
-                        bin = Gst.parseBinFromDescription(Constants.GSTREAMER_PIPELINE_MAC, true);
                     }
                     vc = new GStreamerGrabber();
                     GrabberSingleton.getInstance().pipe.addMany(bin, vc.getElement());
@@ -168,37 +168,15 @@ public class GrabberManager {
      * Old pipeline is not needed anymore, dispose the pipeline and all the related objects to free up system memory.
      */
     private void disposePipeline() {
-        disposePipeline(false);
-    }
-
-    /**
-     * Old pipeline is not needed anymore, dispose the pipeline and all the related objects to free up system memory.
-     *
-     * @param force dispose a still playing pipeline during a restart
-     */
-    private void disposePipeline(boolean force) {
-        if (GrabberSingleton.getInstance().pipe != null && (force || !GrabberSingleton.getInstance().pipe.isPlaying()) && !ManagerSingleton.getInstance().pipelineStarting) {
+        if (GrabberSingleton.getInstance().pipe != null && !GrabberSingleton.getInstance().pipe.isPlaying() && !ManagerSingleton.getInstance().pipelineStarting) {
             log.info("Free up system memory");
-            if (GrabberSingleton.getInstance().pipe.isPlaying()) {
-                GrabberSingleton.getInstance().pipe.stop();
-            }
-            if (bin != null) {
-                Gst.invokeLater(bin::dispose);
-            }
-            if (vc != null) {
-                if (vc.videosink != null) {
-                    Gst.invokeLater(vc.videosink::dispose);
-                }
-                if (vc.getElement() != null) {
-                    Gst.invokeLater(vc.getElement()::dispose);
-                }
-            }
+            Gst.invokeLater(bin::dispose);
+            Gst.invokeLater(vc.videosink::dispose);
+            Gst.invokeLater(vc.getElement()::dispose);
             Gst.invokeLater(GrabberSingleton.getInstance().pipe::dispose);
             GStreamerGrabber.ledMatrix = null;
             bin = null;
-            if (vc != null) {
-                vc.videosink = null;
-            }
+            vc.videosink = null;
             vc = null;
             GrabberSingleton.getInstance().pipe = null;
             System.gc();

--- a/src/main/java/org/dpsoftware/grabber/GrabberManager.java
+++ b/src/main/java/org/dpsoftware/grabber/GrabberManager.java
@@ -305,7 +305,7 @@ public class GrabberManager {
         int benchIteration = Constants.NUMBER_OF_BENCHMARK_ITERATION;
         // Wayland has a more swinging frame rate due to the fact that it doesn't capture an image if frame is still, give it some more room for error.
         if (NativeExecutor.isWayland()) {
-            benchIteration = Constants.NUMBER_OF_BENCHMARK_ITERATION * 4;
+            benchIteration = Constants.NUMBER_OF_BENCHMARK_ITERATION * 10;
         }
         if (!notified.get()) {
             if ((MainSingleton.getInstance().FPS_PRODUCER > 0) && (framerateAlert.get() < benchIteration)

--- a/src/main/java/org/dpsoftware/grabber/ImageProcessor.java
+++ b/src/main/java/org/dpsoftware/grabber/ImageProcessor.java
@@ -82,6 +82,13 @@ public class ImageProcessor {
     }
 
     /**
+     * Reset smoothing history when the LED matrix changes.
+     */
+    public static void resetPreviousColors() {
+        previousColorFloat = null;
+    }
+
+    /**
      * Screen Capture and analysis
      *
      * @param robot an AWT Robot instance for screen capture.
@@ -336,7 +343,7 @@ public class ImageProcessor {
     /**
      * Apply aspect ratio change after debounce
      *
-     * @param aspectRatio
+     * @param aspectRatio aspect ratio to use
      */
     private static void applyAspectRatio(Enums.AspectRatio aspectRatio) {
         if (MainSingleton.getInstance().config.getDefaultLedMatrix().equals(aspectRatio.getBaseI18n())) {
@@ -962,8 +969,8 @@ public class ImageProcessor {
             installationPath = installationPath.substring(6, installationPath.lastIndexOf(Constants.TARGET))
                     + Constants.MAIN_RES;
         }
-        log.info(Constants.GSTREAMER_PATH_IN_USE + "{}", installationPath.replaceAll("%20", " "));
-        return installationPath.replaceAll("%20", " ");
+        log.info(Constants.GSTREAMER_PATH_IN_USE + "{}", installationPath.replace("%20", " "));
+        return installationPath.replace("%20", " ");
     }
 
 }

--- a/src/main/java/org/dpsoftware/grabber/ImageProcessor.java
+++ b/src/main/java/org/dpsoftware/grabber/ImageProcessor.java
@@ -313,11 +313,11 @@ public class ImageProcessor {
         int intBufferSize = (width * height) - 1;
         int[][] blackPixelMatrix;
         blackPixelMatrix = calculateBlackPixels(Enums.AspectRatio.LETTERBOX, width, height, intBufferSize, rgbBuffer);
-        boolean letterbox = switchAspectRatio(Enums.AspectRatio.LETTERBOX, blackPixelMatrix, false);
+        boolean letterbox = switchAspectRatio(Enums.AspectRatio.LETTERBOX, blackPixelMatrix);
         blackPixelMatrix = calculateBlackPixels(Enums.AspectRatio.PILLARBOX, width, height, intBufferSize, rgbBuffer);
         boolean pillarbox = false;
         if (!letterbox) {
-            pillarbox = switchAspectRatio(Enums.AspectRatio.PILLARBOX, blackPixelMatrix, false);
+            pillarbox = switchAspectRatio(Enums.AspectRatio.PILLARBOX, blackPixelMatrix);
         }
         Enums.AspectRatio detected;
         if (letterbox) {
@@ -431,7 +431,7 @@ public class ImageProcessor {
      * @param blackPixelMatrix contains black and non black pixels
      * @return boolean if aspect ratio is changed
      */
-    static boolean switchAspectRatio(Enums.AspectRatio aspectRatio, int[][] blackPixelMatrix, boolean setFullscreen) {
+    static boolean switchAspectRatio(Enums.AspectRatio aspectRatio, int[][] blackPixelMatrix) {
         boolean isPillarboxLetterbox;
         int topMatrix = Arrays.stream(blackPixelMatrix[0]).sum();
         int centerMatrix = Arrays.stream(blackPixelMatrix[1]).sum();
@@ -454,7 +454,7 @@ public class ImageProcessor {
             isPillarboxLetterbox = true;
         } else {
             if (!MainSingleton.getInstance().config.getDefaultLedMatrix().equals(Enums.AspectRatio.FULLSCREEN.getBaseI18n())) {
-                if (setFullscreen && enoughWhitePixelForTheChange) {
+                if (enoughWhitePixelForTheChange) {
                     MainSingleton.getInstance().config.setDefaultLedMatrix(Enums.AspectRatio.FULLSCREEN.getBaseI18n());
                     GStreamerGrabber.ledMatrix = MainSingleton.getInstance().config.getLedMatrixInUse(Enums.AspectRatio.FULLSCREEN.getBaseI18n());
                     log.info("Switching to {} aspect ratio.", Enums.AspectRatio.FULLSCREEN.getBaseI18n());

--- a/src/main/java/org/dpsoftware/gui/GuiManager.java
+++ b/src/main/java/org/dpsoftware/gui/GuiManager.java
@@ -1059,7 +1059,7 @@ public class GuiManager {
      *
      * @param showChangelog show changelog
      */
-    // TODO solo un check non permettere di lanciarne 2 insieme
+    // TODO prevent to launch 2 checks at the same time
     public void showSettingsAndCheckForUpgrade(boolean showChangelog) {
         if (!NativeExecutor.isSystemTraySupported()) {
             showSettingsDialog(false);

--- a/src/main/java/org/dpsoftware/gui/GuiManager.java
+++ b/src/main/java/org/dpsoftware/gui/GuiManager.java
@@ -1059,6 +1059,7 @@ public class GuiManager {
      *
      * @param showChangelog show changelog
      */
+    // TODO solo un check non permettere di lanciarne 2 insieme
     public void showSettingsAndCheckForUpgrade(boolean showChangelog) {
         if (!NativeExecutor.isSystemTraySupported()) {
             showSettingsDialog(false);

--- a/src/main/java/org/dpsoftware/gui/bindings/CommonBinding.java
+++ b/src/main/java/org/dpsoftware/gui/bindings/CommonBinding.java
@@ -75,11 +75,11 @@ public class CommonBinding {
                     List<String> collection = lines.filter(line -> line.startsWith("/")).toList();
                     allPath.addAll(collection);
                 } catch (IOException e) {
-                    log.error("File '{}' could not be loaded", file);
+                    log.warn("File '{}' could not be loaded", file);
                 }
             });
         } catch (IOException e) {
-            log.error("Directory '{}' does not exist", LD_CONFIG);
+            log.warn("Directory '{}' does not exist", LD_CONFIG);
         }
         return allPath;
     }

--- a/src/main/java/org/dpsoftware/gui/controllers/LedsConfigTabController.java
+++ b/src/main/java/org/dpsoftware/gui/controllers/LedsConfigTabController.java
@@ -165,7 +165,8 @@ public class LedsConfigTabController {
         }
         if (currentConfig != null && CommonUtility.isSingleDeviceMultiScreen()) {
             groupBy.setDisable(true);
-            splitBottomMargin.setDisable(true);
+            // TODO
+            //splitBottomMargin.setDisable(true);
             if (MainSingleton.getInstance().config.getMultiMonitor() == 3 && MainSingleton.getInstance().whoAmI == 2) {
                 splitBottomMargin.setDisable(false);
             }
@@ -244,7 +245,8 @@ public class LedsConfigTabController {
         gapTypeTopBottom.setValue(currentConfig.getGapTypeTopBottom());
         gapTypeSide.setValue(currentConfig.getGapTypeSide());
         groupBy.setValue(currentConfig.getGroupBy());
-        forceSingleDeviceMultiScreenValues();
+        // TODO
+//        forceSingleDeviceMultiScreenValues();
         initGroupByCombo();
     }
 

--- a/src/main/java/org/dpsoftware/gui/controllers/LedsConfigTabController.java
+++ b/src/main/java/org/dpsoftware/gui/controllers/LedsConfigTabController.java
@@ -164,12 +164,6 @@ public class LedsConfigTabController {
             ledStartOffset.setDisable(true);
         }
         if (currentConfig != null && CommonUtility.isSingleDeviceMultiScreen()) {
-            groupBy.setDisable(true);
-            // TODO
-            //splitBottomMargin.setDisable(true);
-            if (MainSingleton.getInstance().config.getMultiMonitor() == 3 && MainSingleton.getInstance().whoAmI == 2) {
-                splitBottomMargin.setDisable(false);
-            }
             ledStartOffset.getItems().clear();
             ledStartOffset.getItems().add("0");
         }
@@ -245,50 +239,7 @@ public class LedsConfigTabController {
         gapTypeTopBottom.setValue(currentConfig.getGapTypeTopBottom());
         gapTypeSide.setValue(currentConfig.getGapTypeSide());
         groupBy.setValue(currentConfig.getGroupBy());
-        // TODO
-//        forceSingleDeviceMultiScreenValues();
         initGroupByCombo();
-    }
-
-    /**
-     * Force single device multi screen values
-     */
-    private void forceSingleDeviceMultiScreenValues() {
-        if (CommonUtility.isSingleDeviceMultiScreen()) {
-            switch (MainSingleton.getInstance().whoAmI) {
-                case 1 -> {
-                    if ((MainSingleton.getInstance().config.getMultiMonitor() != 1)) {
-                        // RIGHT
-                        leftLed.setDisable(true);
-                        leftLed.setText(String.valueOf(0));
-                        splitBottomMargin.setValue(Constants.SPLIT_BOTTOM_MARGIN_OFF);
-                    }
-                }
-                case 2 -> {
-                    if ((MainSingleton.getInstance().config.getMultiMonitor() == 2)) {
-                        // LEFT
-                        rightLed.setDisable(true);
-                        rightLed.setText(String.valueOf(0));
-                        splitBottomMargin.setValue(Constants.SPLIT_BOTTOM_MARGIN_OFF);
-                    } else {
-                        // CENTER
-                        leftLed.setDisable(true);
-                        rightLed.setDisable(true);
-                        leftLed.setText(String.valueOf(0));
-                        rightLed.setText(String.valueOf(0));
-                    }
-                }
-                case 3 -> {
-                    // LEFT
-                    rightLed.setDisable(true);
-                    rightLed.setText(String.valueOf(0));
-                    splitBottomMargin.setValue(Constants.SPLIT_BOTTOM_MARGIN_OFF);
-                }
-            }
-            if (CommonUtility.isSingleDeviceOtherInstance()) {
-                ledStartOffset.setValue(String.valueOf(0));
-            }
-        }
     }
 
     /**

--- a/src/main/java/org/dpsoftware/gui/controllers/MiscTabController.java
+++ b/src/main/java/org/dpsoftware/gui/controllers/MiscTabController.java
@@ -113,6 +113,7 @@ public class MiscTabController {
     private Label contextChooseColorChooseLoopback;
     @FXML
     private Label contextGammaGain;
+    private boolean suppressListener = false;
 
     /**
      * Inject main controller containing the TabPane
@@ -239,7 +240,7 @@ public class MiscTabController {
      */
     private void setFramerateIntoConfig(Configuration config) {
         if (LocalizedEnum.fromStr(Enums.Framerate.class, framerate.getValue()) != Enums.Framerate.UNLOCKED) {
-            config.setDesiredFramerate(framerate.getValue().replaceAll(Constants.FPS_VAL, ""));
+            config.setDesiredFramerate(framerate.getValue().replace(Constants.FPS_VAL, ""));
         } else {
             config.setDesiredFramerate(Enums.Framerate.UNLOCKED.getBaseI18n());
         }
@@ -988,9 +989,11 @@ public class MiscTabController {
      * Smoothing management
      */
     public void evaluateSmoothing() {
+        suppressListener = true;
         var smooth = Enums.Smoothing.findByFramerateAndAlpha(MainSingleton.getInstance().config.getFrameInsertionTarget(), MainSingleton.getInstance().config.getEmaAlpha());
         smoothing.setValue(smooth.getI18n());
         setFramerateEditable(smooth);
+        suppressListener = false;
     }
 
     /**
@@ -1072,7 +1075,7 @@ public class MiscTabController {
             if (settingsController != null && settingsController.smoothingDialogController != null) {
                 settingsController.smoothingDialogController.initValuesFromSettingsFile(MainSingleton.getInstance().config);
             }
-            PipelineManager.restartCapture(CommonUtility::run);
+            if (!suppressListener) PipelineManager.restartCapture(CommonUtility::run);
         }
     }
 

--- a/src/main/java/org/dpsoftware/gui/trayicon/TrayIconAppIndicator.java
+++ b/src/main/java/org/dpsoftware/gui/trayicon/TrayIconAppIndicator.java
@@ -166,7 +166,9 @@ public class TrayIconAppIndicator extends TrayIconBase implements TrayIconManage
             } else if (!MainSingleton.getInstance().RUNNING && ManagerSingleton.getInstance().pipelineStarting && !ManagerSingleton.getInstance().pipelineStopping) {
                 setTrayIconImage(Enums.PlayerStatus.PLAY_WAITING);
             } else if (MainSingleton.getInstance().config.isToggleLed()) {
-                setTrayIconImage(Enums.PlayerStatus.STOP);
+                if (!CommonUtility.isSingleDeviceOtherInstance()) {
+                    setTrayIconImage(Enums.PlayerStatus.STOP);
+                }
             } else {
                 setTrayIconImage(Enums.PlayerStatus.OFF);
             }

--- a/src/main/java/org/dpsoftware/gui/trayicon/TrayIconBase.java
+++ b/src/main/java/org/dpsoftware/gui/trayicon/TrayIconBase.java
@@ -53,7 +53,8 @@ public abstract class TrayIconBase extends CommonBinding {
     public String getTooltip() {
         String tooltipStr;
         if (MainSingleton.getInstance().config.getMultiMonitor() > 1) {
-            if (Constants.SERIAL_PORT_AUTO.equals(MainSingleton.getInstance().config.getOutputDevice()) && NetworkManager.isValidIp(MainSingleton.getInstance().config.getStaticGlowWormIp())) {
+            if (Constants.SERIAL_PORT_AUTO.equals(MainSingleton.getInstance().config.getOutputDevice()) && NetworkManager.isValidIp(MainSingleton.getInstance().config.getStaticGlowWormIp())
+                    || Constants.DASH.equals(MainSingleton.getInstance().config.getOutputDevice()) && NetworkManager.isValidIp(MainSingleton.getInstance().config.getStaticGlowWormIp())) {
                 tooltipStr = MainSingleton.getInstance().config.getStaticGlowWormIp();
             } else {
                 tooltipStr = MainSingleton.getInstance().config.getOutputDevice();

--- a/src/main/java/org/dpsoftware/managers/ConfigFileUpgrader.java
+++ b/src/main/java/org/dpsoftware/managers/ConfigFileUpgrader.java
@@ -281,6 +281,23 @@ public record ConfigFileUpgrader(ObjectMapper mapper, String path) {
     }
 
     /**
+     * Update configuration file previous than 2.28.4
+     *
+     * @param config         configuration to update
+     * @param writeToStorage if an update is needed, write to storage
+     * @return true if update is needed
+     */
+    boolean updatePrevious2284(Configuration config, boolean writeToStorage) {
+        if (UpgradeManager.versionNumberToNumber(config.getConfigVersion()) < UpgradeManager.versionNumberToNumber("2.28.4")) {
+            if (config.getUdpTrafficClass() != Constants.DEFAULT_UDP_TRAFFIC_CLASS) {
+                config.setUdpTrafficClass(Constants.DEFAULT_UDP_TRAFFIC_CLASS);
+            }
+            writeToStorage = true;
+        }
+        return writeToStorage;
+    }
+
+    /**
      * Reconfigure LED matrix
      *
      * @param config app config params

--- a/src/main/java/org/dpsoftware/managers/NetworkManager.java
+++ b/src/main/java/org/dpsoftware/managers/NetworkManager.java
@@ -237,13 +237,14 @@ public class NetworkManager implements MqttCallback {
                 ManagerSingleton.getInstance().udpClient.get(deviceToUseIp).manageStream(leds);
                 if (MainSingleton.getInstance().config.getSatellites() != null) {
                     for (Map.Entry<String, Satellite> sat : MainSingleton.getInstance().config.getSatellites().entrySet()) {
-                        if ((ManagerSingleton.getInstance().udpClient == null || ManagerSingleton.getInstance().udpClient.isEmpty())
-                                || ManagerSingleton.getInstance().udpClient.get(sat.getKey()) == null || ManagerSingleton.getInstance().udpClient.get(sat.getKey()).socket.isClosed()) {
-                            assert ManagerSingleton.getInstance().udpClient != null;
-                            ManagerSingleton.getInstance().udpClient.put(sat.getValue().getDeviceIp(), new UdpClient(sat.getValue().getDeviceIp()));
+                        String satIp = sat.getValue().getDeviceIp();
+                        UdpClient satClient = ManagerSingleton.getInstance().udpClient.get(satIp);
+                        if (satClient == null || satClient.socket == null || satClient.socket.isClosed()) {
+                            if (satClient != null) {
+                                satClient.close();
+                            }
+                            ManagerSingleton.getInstance().udpClient.put(satIp, new UdpClient(satIp));
                         }
-                        assert ManagerSingleton.getInstance().udpClient != null;
-                        assert ManagerSingleton.getInstance().udpClient.get(sat.getKey()) == null;
                         sendColorToSatellites(leds, sat.getValue());
                     }
                 }

--- a/src/main/java/org/dpsoftware/managers/NetworkManager.java
+++ b/src/main/java/org/dpsoftware/managers/NetworkManager.java
@@ -249,10 +249,9 @@ public class NetworkManager implements MqttCallback {
                 }
             } catch (SocketException | UnknownHostException e) {
                 log.error(e.getMessage());
-                try {
-                    ManagerSingleton.getInstance().udpClient.get(deviceToUseIp).close();
-                } catch (Exception ex) {
-                    log.error(ex.getMessage());
+                UdpClient client = ManagerSingleton.getInstance().udpClient.get(deviceToUseIp);
+                if (client != null) {
+                    client.close();
                 }
             }
         } else {

--- a/src/main/java/org/dpsoftware/managers/PipelineManager.java
+++ b/src/main/java/org/dpsoftware/managers/PipelineManager.java
@@ -24,6 +24,7 @@ package org.dpsoftware.managers;
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import lombok.extern.slf4j.Slf4j;
+import org.dpsoftware.FireflyLuciferin;
 import org.dpsoftware.LEDCoordinate;
 import org.dpsoftware.MainSingleton;
 import org.dpsoftware.NativeExecutor;
@@ -33,6 +34,7 @@ import org.dpsoftware.config.Constants;
 import org.dpsoftware.config.Enums;
 import org.dpsoftware.config.LocalizedEnum;
 import org.dpsoftware.grabber.DbusScreenCast;
+import org.dpsoftware.grabber.GStreamerGrabber;
 import org.dpsoftware.grabber.GrabberSingleton;
 import org.dpsoftware.grabber.ImageProcessor;
 import org.dpsoftware.gui.GuiSingleton;
@@ -313,9 +315,28 @@ public class PipelineManager {
             }
             CommonUtility.delaySeconds(() -> {
                 if (commandAfter != null) commandAfter.run();
+                refreshCaptureLedState();
                 MainSingleton.getInstance().guiManager.startCapturingThreads();
             }, Constants.TIME_TO_RESTART_CAPTURE);
         });
+    }
+
+    /**
+     * Refresh LED-related runtime caches before the capture pipeline starts again.
+     */
+    public static void refreshCaptureLedState() {
+        if (MainSingleton.getInstance().config == null || NetworkSingleton.getInstance().messageServer == null) {
+            return;
+        }
+        NetworkSingleton.getInstance().messageServer.initNumLed();
+        FireflyLuciferin.setLedNumber(MainSingleton.getInstance().config.getDefaultLedMatrix());
+        LinkedHashMap<Integer, LEDCoordinate> ledMatrix = MainSingleton.getInstance().config.getLedMatrixInUse(MainSingleton.getInstance().config.getDefaultLedMatrix());
+        GrabberSingleton.getInstance().ledMatrix = ledMatrix;
+        GStreamerGrabber.ledMatrix = ledMatrix;
+        if (MainSingleton.getInstance().sharedQueue != null) {
+            MainSingleton.getInstance().sharedQueue.clear();
+        }
+        ImageProcessor.resetPreviousColors();
     }
 
     /**
@@ -349,6 +370,7 @@ public class PipelineManager {
      * Start high performance pipeline, MQTT or Serial managed (FULL or LIGHT firmware)
      */
     public void startCapturePipeline() {
+        refreshCaptureLedState();
         boolean orphanSat = checkForSatelliteOrphans();
         if (orphanSat) {
             MainSingleton.getInstance().guiManager.showLocalizedNotification(Constants.SAT_ZONE_ERROR_TITLE, Constants.SAT_ZONE_ERROR, Constants.FIREFLY_LUCIFERIN, TrayIcon.MessageType.ERROR);

--- a/src/main/java/org/dpsoftware/managers/PipelineManager.java
+++ b/src/main/java/org/dpsoftware/managers/PipelineManager.java
@@ -245,11 +245,11 @@ public class PipelineManager {
         ImageProcessor.exponentialMovingAverage(leds);
         ImageProcessor.adjustStripWhiteBalance(leds);
         if (CommonUtility.isSingleDeviceMultiScreen()) {
-            if (NetworkSingleton.getInstance().msgClient == null || NetworkSingleton.getInstance().msgClient.clientSocket == null) {
+            if (NetworkSingleton.getInstance().msgClient == null) {
                 NetworkSingleton.getInstance().msgClient = new MessageClient();
-                if (CommonUtility.isSingleDeviceMultiScreen()) {
-                    NetworkSingleton.getInstance().msgClient.startConnection(Constants.MSG_SERVER_HOST, Constants.MSG_SERVER_PORT);
-                }
+            }
+            if (!NetworkSingleton.getInstance().msgClient.startConnection(Constants.MSG_SERVER_HOST, Constants.MSG_SERVER_PORT)) {
+                return;
             }
             StringBuilder sb = new StringBuilder();
             sb.append(MainSingleton.getInstance().whoAmI).append(",");

--- a/src/main/java/org/dpsoftware/managers/StorageManager.java
+++ b/src/main/java/org/dpsoftware/managers/StorageManager.java
@@ -396,6 +396,7 @@ public class StorageManager {
         writeToStorage = configFileUpgrader.updatePrevious2226(config, writeToStorage, filename); // Version <= 2.22.6
         writeToStorage = configFileUpgrader.updatePrevious2237(config, writeToStorage); // Version <= 2.23.7
         writeToStorage = configFileUpgrader.updatePrevious2256(config, writeToStorage); // Version <= 2.25.6
+        writeToStorage = configFileUpgrader.updatePrevious2284(config, writeToStorage); // Version <= 2.28.4
         return writeToStorage;
     }
 

--- a/src/main/java/org/dpsoftware/network/MessageClient.java
+++ b/src/main/java/org/dpsoftware/network/MessageClient.java
@@ -154,7 +154,12 @@ public class MessageClient {
         try {
             if (isConnected()) {
                 out.println(msg);
-                return in.readLine();
+                String response = in.readLine();
+                if (response == null) {
+                    closeConnection();
+                    return "";
+                }
+                return response;
             }
         } catch (IOException e) {
             closeConnection();

--- a/src/main/java/org/dpsoftware/network/MessageClient.java
+++ b/src/main/java/org/dpsoftware/network/MessageClient.java
@@ -52,6 +52,7 @@ public class MessageClient {
     public Socket clientSocket;
     private PrintWriter out;
     private BufferedReader in;
+    private long lastConnectionAttempt;
 
     /**
      * Get the main instance status when in multi screen single device
@@ -61,11 +62,16 @@ public class MessageClient {
         // Create a task that runs every 2 seconds
         Runnable framerateTask = () -> {
             try {
-                if (NetworkSingleton.getInstance().msgClient == null || NetworkSingleton.getInstance().msgClient.clientSocket == null) {
+                if (NetworkSingleton.getInstance().msgClient == null) {
                     NetworkSingleton.getInstance().msgClient = new MessageClient();
-                    NetworkSingleton.getInstance().msgClient.startConnection(Constants.MSG_SERVER_HOST, Constants.MSG_SERVER_PORT);
+                }
+                if (!NetworkSingleton.getInstance().msgClient.startConnection(Constants.MSG_SERVER_HOST, Constants.MSG_SERVER_PORT)) {
+                    return;
                 }
                 String response = NetworkSingleton.getInstance().msgClient.sendMessage(Constants.MSG_SERVER_STATUS);
+                if (response.isEmpty()) {
+                    return;
+                }
                 JsonNode stateStatusDto = CommonUtility.fromJsonToObject(response);
                 assert stateStatusDto != null;
                 MainSingleton.getInstance().config.setEffect(stateStatusDto.get(Constants.EFFECT).asText());
@@ -107,14 +113,34 @@ public class MessageClient {
      * @param ip   ip of the msg server
      * @param port port of the msg server
      */
-    public void startConnection(String ip, int port) {
+    public boolean startConnection(String ip, int port) {
+        if (isConnected()) {
+            return true;
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastConnectionAttempt < Constants.UDP_RECONNECT_DELAY_MS) {
+            return false;
+        }
+        lastConnectionAttempt = now;
         try {
             clientSocket = new Socket(ip, port);
             out = new PrintWriter(clientSocket.getOutputStream(), true);
             in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
+            return true;
         } catch (IOException e) {
-            log.error(e.getMessage());
+            closeConnection();
+            log.info("Message server not ready: {}", e.getMessage());
+            return false;
         }
+    }
+
+    /**
+     * Check if the client is connected to the message server.
+     *
+     * @return true if connected
+     */
+    public boolean isConnected() {
+        return clientSocket != null && clientSocket.isConnected() && !clientSocket.isClosed() && out != null && in != null;
     }
 
     /**
@@ -125,27 +151,44 @@ public class MessageClient {
      */
     public String sendMessage(String msg) {
         try {
-            if (out != null) {
+            if (isConnected()) {
                 out.println(msg);
                 return in.readLine();
             }
         } catch (IOException e) {
-            NetworkSingleton.getInstance().msgClient = null;
-            log.error(e.getMessage());
+            closeConnection();
+            log.warn("Message server connection lost: {}", e.getMessage());
         }
         return "";
+    }
+
+    private void closeConnection() {
+        try {
+            if (in != null) {
+                in.close();
+            }
+            if (out != null) {
+                out.close();
+            }
+            if (clientSocket != null) {
+                clientSocket.close();
+            }
+        } catch (IOException e) {
+            log.debug(e.getMessage());
+        } finally {
+            in = null;
+            out = null;
+            clientSocket = null;
+        }
     }
 
     /**
      * Close connection to the msg server
      *
-     * @throws IOException socket error
      */
     @SuppressWarnings("unused")
-    public void stopConnection() throws IOException {
+    public void stopConnection() {
         log.info("Stopping message client");
-        in.close();
-        out.close();
-        clientSocket.close();
+        closeConnection();
     }
 }

--- a/src/main/java/org/dpsoftware/network/MessageClient.java
+++ b/src/main/java/org/dpsoftware/network/MessageClient.java
@@ -113,6 +113,7 @@ public class MessageClient {
      * @param ip   ip of the msg server
      * @param port port of the msg server
      */
+    @SuppressWarnings("all")
     public boolean startConnection(String ip, int port) {
         if (isConnected()) {
             return true;

--- a/src/main/java/org/dpsoftware/network/MessageServer.java
+++ b/src/main/java/org/dpsoftware/network/MessageServer.java
@@ -43,6 +43,7 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.LinkedHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -98,20 +99,60 @@ public class MessageServer {
     /**
      * Init totalNumLed based on all instances
      */
-    public void initNumLed() {
+    public synchronized void initNumLed() {
         StorageManager sm = new StorageManager();
         // Server starts if there are 2 or more monitors
-        monitorConfig1 = sm.readConfigFile(Constants.CONFIG_FILENAME);
-        firstDisplayLedNum = monitorConfig1.getLedMatrix().get(Enums.AspectRatio.FULLSCREEN.getBaseI18n()).size();
-        monitorConfig2 = sm.readConfigFile(Constants.CONFIG_FILENAME_2);
-        secondDisplayLedNum = monitorConfig2.getLedMatrix().get(Enums.AspectRatio.FULLSCREEN.getBaseI18n()).size();
+        Configuration newMonitorConfig1 = sm.readConfigFile(Constants.CONFIG_FILENAME);
+        Configuration newMonitorConfig2 = sm.readConfigFile(Constants.CONFIG_FILENAME_2);
+        Integer newFirstDisplayLedNum = getFullscreenLedNum(newMonitorConfig1);
+        Integer newSecondDisplayLedNum = getFullscreenLedNum(newMonitorConfig2);
+        if (newFirstDisplayLedNum == null || newSecondDisplayLedNum == null) {
+            log.warn("Unable to refresh LED number, keeping previous monitor configuration");
+            return;
+        }
+        monitorConfig1 = newMonitorConfig1;
+        monitorConfig2 = newMonitorConfig2;
+        firstDisplayLedNum = newFirstDisplayLedNum;
+        secondDisplayLedNum = newSecondDisplayLedNum;
         if (MainSingleton.getInstance().config.getMultiMonitor() == 3) {
-            monitorConfig3 = sm.readConfigFile(Constants.CONFIG_FILENAME_3);
-            int thirdDisplayLedNum = monitorConfig3.getLedMatrix().get(Enums.AspectRatio.FULLSCREEN.getBaseI18n()).size();
+            Configuration newMonitorConfig3 = sm.readConfigFile(Constants.CONFIG_FILENAME_3);
+            Integer thirdDisplayLedNum = getFullscreenLedNum(newMonitorConfig3);
+            if (thirdDisplayLedNum == null) {
+                log.warn("Unable to refresh LED number, keeping previous monitor configuration");
+                return;
+            }
+            monitorConfig3 = newMonitorConfig3;
             NetworkSingleton.getInstance().totalLedNum = firstDisplayLedNum + secondDisplayLedNum + thirdDisplayLedNum;
         } else {
             NetworkSingleton.getInstance().totalLedNum = firstDisplayLedNum + secondDisplayLedNum;
         }
+        if (leds == null || leds.length != NetworkSingleton.getInstance().totalLedNum) {
+            leds = new Color[NetworkSingleton.getInstance().totalLedNum];
+            resetDisplayReceived();
+        }
+    }
+
+    /**
+     * Get fullscreen LED count from a monitor configuration.
+     *
+     * @param config monitor configuration
+     * @return LED count, null when config is temporarily unavailable or incomplete
+     */
+    private Integer getFullscreenLedNum(Configuration config) {
+        if (config == null || config.getLedMatrix() == null) {
+            return null;
+        }
+        LinkedHashMap<Integer, org.dpsoftware.LEDCoordinate> fullscreenLedMatrix = config.getLedMatrix().get(Enums.AspectRatio.FULLSCREEN.getBaseI18n());
+        return fullscreenLedMatrix == null ? null : fullscreenLedMatrix.size();
+    }
+
+    /**
+     * Reset received-frame flags when LED buffers are rebuilt.
+     */
+    private void resetDisplayReceived() {
+        firstDisplayReceived = false;
+        secondDisplayReceived = false;
+        thirdDisplayReceived = false;
     }
 
     /**
@@ -180,35 +221,82 @@ public class MessageServer {
      * @param inputLine message received from the client
      * @param out       response sent to the client
      */
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private void collectAndSendData(String inputLine, PrintWriter out) {
-        String[] ledsString = inputLine.split(",");
-        int instanceNumber = Integer.parseInt(ledsString[0]);
-        int startIndex = 0;
-        if (instanceNumber == 1) {
-            firstDisplayReceived = true;
-            startIndex = -1;
-        } else if (instanceNumber == 2) {
-            secondDisplayReceived = true;
-            startIndex = firstDisplayLedNum - 1;
-        } else if (instanceNumber == 3) {
-            thirdDisplayReceived = true;
-            startIndex = (firstDisplayLedNum + secondDisplayLedNum) - 1;
+        try {
+            initNumLed();
+            String[] ledsString = inputLine.split(",");
+            int instanceNumber = Integer.parseInt(ledsString[0]);
+            int receivedLedNum = ledsString.length - 1;
+            int expectedLedNum = getExpectedLedNum(instanceNumber);
+            if (expectedLedNum == 0 || receivedLedNum != expectedLedNum) {
+                log.debug("Led number has changed");
+                resetDisplayReceived();
+                initNumLed();
+                out.println(inputLine);
+                return;
+            }
+            int startIndex;
+            if (instanceNumber == 1) {
+                firstDisplayReceived = true;
+                startIndex = -1;
+            } else if (instanceNumber == 2) {
+                secondDisplayReceived = true;
+                startIndex = firstDisplayLedNum - 1;
+            } else if (instanceNumber == 3) {
+                thirdDisplayReceived = true;
+                startIndex = (firstDisplayLedNum + secondDisplayLedNum) - 1;
+            } else {
+                out.println(inputLine);
+                return;
+            }
+            for (int i = 1; i <= ledsString.length - 1; i++) {
+                leds[startIndex + i] = new Color(Integer.parseInt(ledsString[i]));
+            }
+            if (MainSingleton.getInstance().config.getMultiMonitor() == 2 && firstDisplayReceived && secondDisplayReceived) {
+                firstDisplayReceived = false;
+                secondDisplayReceived = false;
+                offerCompleteFrame();
+            } else if (MainSingleton.getInstance().config.getMultiMonitor() == 3 && firstDisplayReceived && secondDisplayReceived && thirdDisplayReceived) {
+                firstDisplayReceived = false;
+                secondDisplayReceived = false;
+                thirdDisplayReceived = false;
+                offerCompleteFrame();
+            }
+            out.println(inputLine);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            log.debug("Led number has changed");
+            initNumLed();
+            out.println(inputLine);
         }
-        for (int i = 1; i <= ledsString.length - 1; i++) {
-            leds[startIndex + i] = new Color(Integer.parseInt(ledsString[i]));
+    }
+
+    /**
+     * Get expected LED count for a monitor instance.
+     *
+     * @param instanceNumber monitor instance number
+     * @return expected LED count
+     */
+    private int getExpectedLedNum(int instanceNumber) {
+        return switch (instanceNumber) {
+            case 1 -> firstDisplayLedNum;
+            case 2 -> secondDisplayLedNum;
+            case 3 ->
+                    MainSingleton.getInstance().config.getMultiMonitor() == 3 && monitorConfig3 != null ? getFullscreenLedNum(monitorConfig3) : 0;
+            default -> 0;
+        };
+    }
+
+    /**
+     * Offer a frame only when all LEDs have been filled with the current matrix size.
+     */
+    private void offerCompleteFrame() {
+        for (Color led : leds) {
+            if (led == null) {
+                resetDisplayReceived();
+                return;
+            }
         }
-        if (MainSingleton.getInstance().config.getMultiMonitor() == 2 && firstDisplayReceived && secondDisplayReceived) {
-            firstDisplayReceived = false;
-            secondDisplayReceived = false;
-            MainSingleton.getInstance().sharedQueue.offer(leds);
-        } else if (MainSingleton.getInstance().config.getMultiMonitor() == 3 && firstDisplayReceived && secondDisplayReceived && thirdDisplayReceived) {
-            firstDisplayReceived = false;
-            secondDisplayReceived = false;
-            thirdDisplayReceived = false;
-            MainSingleton.getInstance().sharedQueue.offer(leds);
-        }
-        out.println(inputLine);
+        MainSingleton.getInstance().sharedQueue.offer(leds);
     }
 
     /**

--- a/src/main/java/org/dpsoftware/network/MessageServer.java
+++ b/src/main/java/org/dpsoftware/network/MessageServer.java
@@ -40,8 +40,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Message server using Java Sockets, used for single instance multi monitor
@@ -59,6 +63,7 @@ public class MessageServer {
     private int secondDisplayLedNum = 0;
     private ServerSocket serverSocket;
     private Configuration monitorConfig1, monitorConfig2, monitorConfig3;
+    private ScheduledExecutorService serverWatchdog;
 
     private static StateStatusDto getStateStatusDto() {
         StateStatusDto stateStatusDto = new StateStatusDto();
@@ -74,13 +79,20 @@ public class MessageServer {
      * Start message server for multi screen, single instance
      */
     public void startMessageServer() {
-        CommonUtility.delaySeconds(() -> {
-            try {
-                NetworkSingleton.getInstance().messageServer.start(Constants.MSG_SERVER_PORT);
-            } catch (IOException e) {
-                log.error(e.getMessage());
+        if (serverWatchdog != null && !serverWatchdog.isShutdown()) {
+            return;
+        }
+        serverWatchdog = Executors.newSingleThreadScheduledExecutor();
+        serverWatchdog.scheduleWithFixedDelay(() -> {
+            if (isRunning()) {
+                return;
             }
-        }, 0);
+            try {
+                start(Constants.MSG_SERVER_PORT);
+            } catch (IOException e) {
+                log.error("Unable to start message server: {}", e.getMessage());
+            }
+        }, 0, 2, TimeUnit.SECONDS);
     }
 
     /**
@@ -111,7 +123,8 @@ public class MessageServer {
     public void start(int port) throws IOException {
         log.info("Starting message server");
         leds = new Color[NetworkSingleton.getInstance().totalLedNum];
-        serverSocket = new ServerSocket(port);
+        serverSocket = new ServerSocket(port, 50, InetAddress.getByName(Constants.MSG_SERVER_HOST));
+        log.info("Message server listening on {}:{}", Constants.MSG_SERVER_HOST, port);
         while (!NetworkSingleton.getInstance().closeServer) {
             if (!serverSocket.isClosed()) {
                 new ClientHandler(serverSocket.accept()).start();
@@ -129,6 +142,18 @@ public class MessageServer {
         if (serverSocket != null) {
             serverSocket.close();
         }
+        if (serverWatchdog != null) {
+            serverWatchdog.shutdownNow();
+        }
+    }
+
+    /**
+     * Check if message server is listening.
+     *
+     * @return true if server socket is open
+     */
+    public boolean isRunning() {
+        return serverSocket != null && !serverSocket.isClosed();
     }
 
     /**

--- a/src/main/java/org/dpsoftware/network/NetworkSingleton.java
+++ b/src/main/java/org/dpsoftware/network/NetworkSingleton.java
@@ -194,5 +194,32 @@ public class NetworkSingleton {
         orderZonedList(zonedList, config2, orderedList);
         orderedList.toArray(colorArray);
     }
-}
 
+    /**
+     * Check if the multi screen single device LED stream must be reordered.
+     * Reordering is needed when at least one monitor does not have a full strip around all its sides.
+     *
+     * @return true if LED data must be reordered before sending it to the device
+     */
+    public boolean isLedOrderRequired() {
+        if (messageServer == null || !CommonUtility.isSingleDeviceMultiScreen()) {
+            return false;
+        }
+        if (messageServer.getMonitorConfig1() == null || messageServer.getMonitorConfig2() == null
+                || (MainSingleton.getInstance().config.getMultiMonitor() == 3 && messageServer.getMonitorConfig3() == null)) {
+            return false;
+        }
+        if (MainSingleton.getInstance().config.getMultiMonitor() == 3) {
+            return messageServer.getMonitorConfig1().getLeftLed() == 0
+                    && messageServer.getMonitorConfig2().getLeftLed() == 0
+                    && messageServer.getMonitorConfig2().getRightLed() == 0
+                    && messageServer.getMonitorConfig3().getRightLed() == 0;
+        }
+        if (MainSingleton.getInstance().config.getMultiMonitor() == 2) {
+            return messageServer.getMonitorConfig1().getLeftLed() == 0
+                    && messageServer.getMonitorConfig2().getRightLed() == 0;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpClient.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpClient.java
@@ -163,26 +163,27 @@ public class UdpClient {
     /**
      * UDP priority is really important for latency.
      * Linux firewalls may block "unusual" priority classes
-     * | Traffic class               | Decimal value   | Hex value          |
-     * |-----------------------------|-----------------|--------------------|
-     * | Network Control             | 56              | 0x38               |
-     * | Internetwork Control        | 48              | 0x30               |
-     * | Expedited Forwarding        | 46              | 0x2E               |
-     * | Voice, less than 10ms       | 40              | 0x28               |
-     * | Video, less than 100ms      | 32              | 0x20               |
-     * | Assured Forwarding Class 4  | 34              | 0x22               |
-     * | Assured Forwarding Class 3  | 26              | 0x1A               |
-     * | Assured Forwarding Class 2  | 18              | 0x12               |
-     * | Critical Applications       | 24              | 0x18               |
-     * | Assured Forwarding Class 1  | 10              | 0x0A               |
-     * | Excellent Effort            | 16              | 0x10               |
-     * | Background                  | 8               | 0x08               |
+     * |------------------------------ |----------|-----------|------------------|------------------|
+     * | QoS Class                     | DSCP Dec | DSCP Hex  | TrafficClass Dec | TrafficClass Hex |
+     * |------------------------------ |----------|-----------|------------------|------------------|
+     * | Network Control              | 56       | 0x38      | 224              | 0xE0             |
+     * | Internetwork Control         | 48       | 0x30      | 192              | 0xC0             |
+     * | Expedited Forwarding (EF)    | 46       | 0x2E      | 184              | 0xB8             |
+     * | Voice, less than 10ms        | 40       | 0x28      | 160              | 0xA0             |
+     * | Video, less than 100ms       | 32       | 0x20      | 128              | 0x80             |
+     * | Assured Forwarding Class 4   | 34       | 0x22      | 136              | 0x88             |
+     * | Assured Forwarding Class 3   | 26       | 0x1A      | 104              | 0x68             |
+     * | Assured Forwarding Class 2   | 18       | 0x12      | 72               | 0x48             |
+     * | Critical Applications        | 24       | 0x18      | 96               | 0x60             |
+     * | Assured Forwarding Class 1   | 10       | 0x0A      | 40               | 0x28             |
+     * | Excellent Effort             | 16       | 0x10      | 64               | 0x40             |
+     * | Background                   | 8        | 0x08      | 32               | 0x20             |
      */
     private void setTrafficClass() {
         try {
             socket.setTrafficClass(MainSingleton.getInstance().config.getUdpTrafficClass());
         } catch (SocketException e) {
-            log.warn("Cannot set UDP traffic class (not supported on this OS/NIC): {}", e.getMessage());
+            log.warn("Cannot set UDP traffic class {}, (not supported on this OS/NIC): {}", MainSingleton.getInstance().config.getUdpTrafficClass(), e.getMessage());
         }
     }
 

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpClient.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpClient.java
@@ -192,8 +192,12 @@ public class UdpClient {
      * | Excellent Effort            | 16              | 0x10               |
      * | Background                  | 8               | 0x08               |
      */
-    private void setTrafficClass() throws SocketException {
-        socket.setTrafficClass(MainSingleton.getInstance().config.getUdpTrafficClass());
+    private void setTrafficClass() {
+        try {
+            socket.setTrafficClass(MainSingleton.getInstance().config.getUdpTrafficClass());
+        } catch (SocketException e) {
+            log.warn("Cannot set UDP traffic class (not supported on this OS/NIC): {}", e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpClient.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpClient.java
@@ -77,7 +77,7 @@ public class UdpClient {
     }
 
     /**
-     * Find the local IPv4 address that belongs to the same subnet as the target device.
+     * Find the local IPv4 address that the OS routing table would use for the target device.
      *
      * @param targetAddress device IP address
      * @return matching local IPv4 address, or null if none is found
@@ -102,10 +102,10 @@ public class UdpClient {
                 if (!(localAddress instanceof Inet4Address)) {
                     continue;
                 }
-                boolean sameSubnet = isAddressInSameSubnet(interfaceAddress, targetAddress.getHostAddress());
-                log.debug("UDP stream subnet check localIp={}, targetIp={}, prefixLength={}, result={}",
-                        localAddress.getHostAddress(), targetAddress.getHostAddress(), interfaceAddress.getNetworkPrefixLength(), sameSubnet);
-                if (sameSubnet) {
+                boolean routedViaInterface = isReachableViaInterface(localAddress, targetAddress);
+                log.debug("UDP stream routing check localIp={}, targetIp={}, result={}",
+                        localAddress.getHostAddress(), targetAddress.getHostAddress(), routedViaInterface);
+                if (routedViaInterface) {
                     log.debug("Selected UDP stream interface {} with localIp={} for targetIp={}",
                             networkInterface.getDisplayName(), localAddress.getHostAddress(), targetAddress.getHostAddress());
                     return localAddress;
@@ -138,40 +138,26 @@ public class UdpClient {
     }
 
     /**
-     * Check if a target IP belongs to the same subnet of an interface.
+     * Check if a target IP is routable via a specific local interface address.
      *
-     * @param interfaceAddress interface to check
-     * @param targetIp         target IP address
-     * @return true if the target IP belongs to the same subnet
+     * @param localAddress  local interface address to bind to
+     * @param targetAddress target IP address
+     * @return true if the OS routes the target through the local interface
      */
-    private boolean isAddressInSameSubnet(InterfaceAddress interfaceAddress, String targetIp) {
-        if (!NetworkManager.isValidIp(targetIp) || interfaceAddress == null || interfaceAddress.getAddress() == null) {
+    private boolean isReachableViaInterface(InetAddress localAddress, InetAddress targetAddress) {
+        if (localAddress == null || targetAddress == null || !NetworkManager.isValidIp(targetAddress.getHostAddress())) {
             return false;
         }
-        short prefixLength = interfaceAddress.getNetworkPrefixLength();
-        if (prefixLength < 0 || prefixLength > 32) {
+        try (DatagramSocket testSocket = new DatagramSocket(null)) {
+            testSocket.bind(new InetSocketAddress(localAddress, 0));
+            testSocket.connect(new InetSocketAddress(targetAddress, UDP_PORT));
+            InetAddress routedVia = testSocket.getLocalAddress();
+            return routedVia != null && routedVia.equals(localAddress);
+        } catch (Exception e) {
+            log.debug("UDP stream routing check failed for localIp={} targetIp={}: {}",
+                    localAddress.getHostAddress(), targetAddress.getHostAddress(), e.getMessage());
             return false;
         }
-        byte[] localAddress = interfaceAddress.getAddress().getAddress();
-        byte[] targetAddress;
-        try {
-            targetAddress = InetAddress.getByName(targetIp).getAddress();
-        } catch (UnknownHostException e) {
-            return false;
-        }
-        // Split the CIDR prefix into full bytes plus any remaining bits of the next byte.
-        int fullBytes = prefixLength / 8;
-        int remainingBits = prefixLength % 8;
-        for (int index = 0; index < fullBytes; index++) {
-            if (localAddress[index] != targetAddress[index]) {
-                return false;
-            }
-        }
-        if (remainingBits == 0) {
-            return true;
-        }
-        int mask = (0xFF << (8 - remainingBits)) & 0xFF;
-        return (localAddress[fullBytes] & mask) == (targetAddress[fullBytes] & mask);
     }
 
     /**

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
@@ -237,19 +237,44 @@ public class UdpServer {
                         log.debug("Skipping IPv4 {} because it has no broadcast address", address.getHostAddress());
                     }
                 } else {
-                    boolean sameSubnet = isAddressInSameSubnet(interfaceAddress, staticGlowWormIp);
-                    if (sameSubnet) {
+                    if (isReachableViaInterface(address, staticGlowWormIp)) {
                         interfaceAddresses.add(interfaceAddress);
                         log.debug("Selected interface {} with IPv4 {} for static target {}",
                                 networkInterface.getDisplayName(), address.getHostAddress(), staticGlowWormIp);
                     } else {
-                        log.debug("Skipping IPv4 {} because it is not in the same subnet as {}",
+                        log.debug("Skipping {} because it is not reachable to static target {} according to OS routing table",
                                 address.getHostAddress(), staticGlowWormIp);
                     }
                 }
             }
         }
         return interfaceAddresses;
+    }
+
+    /**
+     * Check if a target IP is routable via a specific local interface address,
+     * by binding a UDP socket to that interface and connecting toward the target.
+     * No actual traffic is sent — connect() on UDP just asks the OS routing table.
+     *
+     * @param localAddress the local interface address to bind to
+     * @param targetIp     the static Glow Worm IP to reach
+     * @return true if the OS routing table can route the target via this interface
+     */
+    private boolean isReachableViaInterface(InetAddress localAddress, String targetIp) {
+        try (DatagramSocket testSocket = new DatagramSocket(null)) {
+            testSocket.bind(new InetSocketAddress(localAddress, 0));
+            testSocket.connect(new InetSocketAddress(targetIp, Constants.UDP_BROADCAST_PORT));
+            InetAddress routedVia = testSocket.getLocalAddress();
+            boolean match = routedVia != null && routedVia.equals(localAddress);
+            log.debug("Routing check localIp={} targetIp={} routedVia={} match={}",
+                    localAddress.getHostAddress(), targetIp,
+                    routedVia != null ? routedVia.getHostAddress() : "null", match);
+            return match;
+        } catch (Exception e) {
+            log.debug("isReachableViaInterface failed for localIp={} targetIp={}: {}",
+                    localAddress.getHostAddress(), targetIp, e.getMessage());
+            return false;
+        }
     }
 
     /**
@@ -284,49 +309,6 @@ public class UdpServer {
                 && !networkInterface.isVirtual()
                 && !networkInterface.isPointToPoint()
                 && !interfaceMatchesExcludedKeywords(networkInterface);
-    }
-
-    /**
-     * Check if a target IP belongs to the same subnet of an interface.
-     *
-     * @param interfaceAddress interface to check
-     * @param targetIp         target IP address
-     * @return true if the target IP belongs to the same subnet
-     */
-    private boolean isAddressInSameSubnet(InterfaceAddress interfaceAddress, String targetIp) {
-        if (!NetworkManager.isValidIp(targetIp) || interfaceAddress == null || interfaceAddress.getAddress() == null) {
-            log.debug("Cannot evaluate subnet match for interfaceAddress={} and targetIp={}", interfaceAddress, targetIp);
-            return false;
-        }
-        short prefixLength = interfaceAddress.getNetworkPrefixLength();
-        if (prefixLength < 0 || prefixLength > 32) {
-            log.debug("Invalid prefixLength={} for address={}", prefixLength, interfaceAddress.getAddress().getHostAddress());
-            return false;
-        }
-        byte[] localAddress = interfaceAddress.getAddress().getAddress();
-        byte[] targetAddress;
-        try {
-            targetAddress = InetAddress.getByName(targetIp).getAddress();
-        } catch (UnknownHostException e) {
-            log.debug("Unable to resolve staticGlowWormIp={} while checking subnet match", targetIp);
-            return false;
-        }
-        // Split the CIDR prefix into full bytes plus any remaining bits of the next byte.
-        int fullBytes = prefixLength / 8;
-        int remainingBits = prefixLength % 8;
-        for (int index = 0; index < fullBytes; index++) {
-            if (localAddress[index] != targetAddress[index]) {
-                return false;
-            }
-        }
-        if (remainingBits == 0) {
-            return true;
-        }
-        int mask = (0xFF << (8 - remainingBits)) & 0xFF;
-        boolean sameSubnet = (localAddress[fullBytes] & mask) == (targetAddress[fullBytes] & mask);
-        log.debug("Subnet match check localIp={}, targetIp={}, prefixLength={}, result={}",
-                interfaceAddress.getAddress().getHostAddress(), targetIp, prefixLength, sameSubnet);
-        return sameSubnet;
     }
 
     /**

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
@@ -31,7 +31,6 @@ import org.dpsoftware.gui.GuiSingleton;
 import org.dpsoftware.gui.elements.Satellite;
 import org.dpsoftware.managers.ManagerSingleton;
 import org.dpsoftware.managers.NetworkManager;
-// TODO remove or not
 import org.dpsoftware.managers.dto.TcpResponse;
 import org.dpsoftware.network.NetworkSingleton;
 import org.dpsoftware.utilities.CommonUtility;
@@ -348,8 +347,6 @@ public class UdpServer {
         }
         socket.send(packet);
     }
-
-    // TODO remove or not
 
     /**
      *

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
@@ -51,12 +51,21 @@ public class UdpServer {
     DatagramSocket socket;
     List<InterfaceAddress> eligibleInterfaceAddresses = Collections.emptyList();
     boolean firstConnection = true;
+    private ScheduledExecutorService socketRetryExecutor;
+    private boolean udpReceiverStarted = false;
 
     /**
      * Initialize the main socket for receiving devices infos.
      * Find local IP address, used to get local broadcast address. This way works well when there are multiple network interfaces.
      */
     public UdpServer() {
+        initSocket();
+    }
+
+    private void initSocket() {
+        if (isSocketAvailable()) {
+            return;
+        }
         try {
             if (MainSingleton.getInstance().whoAmI == 1) {
                 socket = new DatagramSocket(Constants.UDP_BROADCAST_PORT);
@@ -92,10 +101,33 @@ public class UdpServer {
     @SuppressWarnings("Duplicates")
     public void receiveBroadcastUDPPacket() {
         if (!isSocketAvailable()) {
-            NetworkSingleton.getInstance().udpBroadcastReceiverRunning = false;
-            log.warn("UDP discovery disabled because the socket is not available");
+            retrySocketInitialization();
             return;
         }
+        startUdpReceiver();
+    }
+
+    private void retrySocketInitialization() {
+        if (socketRetryExecutor != null && !socketRetryExecutor.isShutdown()) {
+            return;
+        }
+        log.warn("UDP discovery socket is not available, retrying bind in background");
+        socketRetryExecutor = Executors.newSingleThreadScheduledExecutor();
+        socketRetryExecutor.scheduleWithFixedDelay(() -> {
+            initSocket();
+            if (isSocketAvailable()) {
+                socketRetryExecutor.shutdown();
+                startUdpReceiver();
+            }
+        }, 1, 1, TimeUnit.SECONDS);
+    }
+
+    private void startUdpReceiver() {
+        if (udpReceiverStarted) {
+            return;
+        }
+        udpReceiverStarted = true;
+        NetworkSingleton.getInstance().udpBroadcastReceiverRunning = true;
         broadcastToCorrectNetworkAdapter();
         CompletableFuture.supplyAsync(() -> {
             try {

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
@@ -31,6 +31,8 @@ import org.dpsoftware.gui.GuiSingleton;
 import org.dpsoftware.gui.elements.Satellite;
 import org.dpsoftware.managers.ManagerSingleton;
 import org.dpsoftware.managers.NetworkManager;
+// TODO remove or not
+import org.dpsoftware.managers.dto.TcpResponse;
 import org.dpsoftware.network.NetworkSingleton;
 import org.dpsoftware.utilities.CommonUtility;
 
@@ -411,6 +413,9 @@ public class UdpServer {
                                 broadCastPing.getAddress() != null ? broadCastPing.getAddress().getHostAddress() : "unknown",
                                 useBroadcast ? Constants.UDP_DEVICE_NAME : Constants.UDP_DEVICE_NAME_STATIC);
                         sendFromInterface(interfaceAddress, broadCastPing);
+                        if (!useBroadcast) {
+                            sendTcpPing(interfaceAddress, broadCastPing);
+                        }
                         for (Map.Entry<String, Satellite> sat : MainSingleton.getInstance().config.getSatellites().entrySet()) {
                             if (!isReachableViaInterface(interfaceAddress.getAddress(), sat.getValue().getDeviceIp())) {
                                 log.trace("Skipping UDP satellite device-name packet from interfaceIp={} to satelliteIp={} because route does not use this interface",
@@ -423,6 +428,9 @@ public class UdpServer {
                                     interfaceAddress.getAddress() != null ? interfaceAddress.getAddress().getHostAddress() : "unknown",
                                     sat.getValue().getDeviceIp());
                             sendFromInterface(interfaceAddress, broadCastPing);
+                            if (!useBroadcast) {
+                                sendTcpPing(interfaceAddress, broadCastPing);
+                            }
                         }
                     }
                 }
@@ -431,6 +439,23 @@ public class UdpServer {
             }
         };
         udpIpExecutorService.scheduleAtFixedRate(setIpTask, 0, 2, TimeUnit.SECONDS);
+    }
+
+    // TODO remove or not
+
+    /**
+     *
+     * @param interfaceAddress local interface used for the outgoing packet
+     * @param packet           packet to send
+     */
+    public void sendTcpPing(InterfaceAddress interfaceAddress, DatagramPacket packet) {
+        boolean deviceFound = GuiSingleton.getInstance().deviceTableData != null
+                && GuiSingleton.getInstance().deviceTableData.stream()
+                .anyMatch(d -> d.getDeviceIP().equals(packet.getAddress().getHostAddress()));
+        if (!deviceFound) {
+            TcpResponse tcpResponse = TcpClient.httpGet(interfaceAddress.getAddress().getHostAddress(), Constants.HTTP_SET_IP, packet.getAddress().getHostAddress());
+            log.debug("TCP ping http://{}?setip?payload={} with response code: {}", interfaceAddress.getAddress().getHostAddress(), packet.getAddress().getHostAddress(), tcpResponse.getErrorCode());
+        }
     }
 
     /**

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
@@ -349,6 +349,30 @@ public class UdpServer {
         socket.send(packet);
     }
 
+    // TODO remove or not
+
+    /**
+     *
+     * @param interfaceAddress local interface used for the outgoing packet
+     * @param packet           packet to send
+     */
+    public void sendTcpPing(InterfaceAddress interfaceAddress, DatagramPacket packet) {
+        boolean deviceFound = GuiSingleton.getInstance().deviceTableData != null
+                && GuiSingleton.getInstance().deviceTableData.stream()
+                .anyMatch(d -> d.getDeviceIP().equals(packet.getAddress().getHostAddress()));
+        if (!deviceFound) {
+            CommonUtility.delaySeconds(() -> {
+                boolean isPresentNow = GuiSingleton.getInstance().deviceTableData != null
+                        && GuiSingleton.getInstance().deviceTableData.stream()
+                        .anyMatch(d -> d.getDeviceIP().equals(packet.getAddress().getHostAddress()));
+                if (!isPresentNow) {
+                    TcpResponse tcpResponse = TcpClient.httpGet(interfaceAddress.getAddress().getHostAddress(), Constants.HTTP_SET_IP, packet.getAddress().getHostAddress());
+                    log.debug("TCP ping http://{}?setip?payload={} with response code: {}", interfaceAddress.getAddress().getHostAddress(), packet.getAddress().getHostAddress(), tcpResponse.getErrorCode());
+                }
+            }, 10);
+        }
+    }
+
     /**
      * Validate a network interface before using it for discovery.
      *
@@ -439,23 +463,6 @@ public class UdpServer {
             }
         };
         udpIpExecutorService.scheduleAtFixedRate(setIpTask, 0, 2, TimeUnit.SECONDS);
-    }
-
-    // TODO remove or not
-
-    /**
-     *
-     * @param interfaceAddress local interface used for the outgoing packet
-     * @param packet           packet to send
-     */
-    public void sendTcpPing(InterfaceAddress interfaceAddress, DatagramPacket packet) {
-        boolean deviceFound = GuiSingleton.getInstance().deviceTableData != null
-                && GuiSingleton.getInstance().deviceTableData.stream()
-                .anyMatch(d -> d.getDeviceIP().equals(packet.getAddress().getHostAddress()));
-        if (!deviceFound) {
-            TcpResponse tcpResponse = TcpClient.httpGet(interfaceAddress.getAddress().getHostAddress(), Constants.HTTP_SET_IP, packet.getAddress().getHostAddress());
-            log.debug("TCP ping http://{}?setip?payload={} with response code: {}", interfaceAddress.getAddress().getHostAddress(), packet.getAddress().getHostAddress(), tcpResponse.getErrorCode());
-        }
     }
 
     /**

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
@@ -65,12 +65,19 @@ public class UdpServer {
             } else if (MainSingleton.getInstance().whoAmI == 3) {
                 socket = new DatagramSocket(Constants.UDP_BROADCAST_PORT_3);
             }
-            assert socket != null;
+            if (socket == null) {
+                log.warn("UDP discovery socket not initialized for instance={}", MainSingleton.getInstance().whoAmI);
+                return;
+            }
             socket.setBroadcast(true);
             log.debug("UDP discovery socket initialized on port={}", socket.getLocalPort());
         } catch (SocketException e) {
             log.error(e.getMessage());
         }
+    }
+
+    private boolean isSocketAvailable() {
+        return socket != null && !socket.isClosed();
     }
 
     private static boolean interfaceMatchesExcludedKeywords(NetworkInterface networkInterface) {
@@ -84,9 +91,17 @@ public class UdpServer {
      */
     @SuppressWarnings("Duplicates")
     public void receiveBroadcastUDPPacket() {
+        if (!isSocketAvailable()) {
+            NetworkSingleton.getInstance().udpBroadcastReceiverRunning = false;
+            log.warn("UDP discovery disabled because the socket is not available");
+            return;
+        }
         broadcastToCorrectNetworkAdapter();
         CompletableFuture.supplyAsync(() -> {
             try {
+                if (!isSocketAvailable()) {
+                    return null;
+                }
                 log.debug("UDP broadcast listen on {}", socket.getLocalAddress());
                 byte[] buf = new byte[512];
                 DatagramPacket packet = new DatagramPacket(buf, buf.length);
@@ -169,6 +184,10 @@ public class UdpServer {
      */
     @SuppressWarnings("Duplicates")
     void broadcastToCorrectNetworkAdapter() {
+        if (!isSocketAvailable()) {
+            log.warn("Skipping UDP discovery tasks because the socket is not available");
+            return;
+        }
         try {
             boolean useBroadcast = !NetworkManager.isValidIp(MainSingleton.getInstance().config.getStaticGlowWormIp());
             log.debug("Starting UDP discovery. mode={}, staticGlowWormIp={}",
@@ -278,6 +297,25 @@ public class UdpServer {
     }
 
     /**
+     * Send a UDP packet using the given local interface as source address.
+     *
+     * @param interfaceAddress local interface used for the outgoing packet
+     * @param packet           packet to send
+     * @throws IOException if send fails
+     */
+    private void sendFromInterface(InterfaceAddress interfaceAddress, DatagramPacket packet) throws IOException {
+        InetAddress localAddress = interfaceAddress != null ? interfaceAddress.getAddress() : null;
+        if (localAddress instanceof Inet4Address) {
+            try (DatagramSocket interfaceSocket = new DatagramSocket(new InetSocketAddress(localAddress, 0))) {
+                interfaceSocket.setBroadcast(true);
+                interfaceSocket.send(packet);
+                return;
+            }
+        }
+        socket.send(packet);
+    }
+
+    /**
      * Validate a network interface before using it for discovery.
      *
      * @param networkInterface interface to check
@@ -322,6 +360,10 @@ public class UdpServer {
         ScheduledExecutorService udpIpExecutorService = Executors.newScheduledThreadPool(1);
         Runnable setIpTask = () -> {
             try {
+                if (!isSocketAvailable()) {
+                    udpIpExecutorService.shutdown();
+                    return;
+                }
                 DatagramPacket broadCastPing;
                 // Send the name of the device where Firefly wants to connect
                 if (!Constants.SERIAL_PORT_AUTO.equals(MainSingleton.getInstance().config.getOutputDevice())) {
@@ -336,13 +378,19 @@ public class UdpServer {
                                 interfaceAddress.getAddress() != null ? interfaceAddress.getAddress().getHostAddress() : "unknown",
                                 broadCastPing.getAddress() != null ? broadCastPing.getAddress().getHostAddress() : "unknown",
                                 useBroadcast ? Constants.UDP_DEVICE_NAME : Constants.UDP_DEVICE_NAME_STATIC);
-                        socket.send(broadCastPing);
+                        sendFromInterface(interfaceAddress, broadCastPing);
                         for (Map.Entry<String, Satellite> sat : MainSingleton.getInstance().config.getSatellites().entrySet()) {
+                            if (!isReachableViaInterface(interfaceAddress.getAddress(), sat.getValue().getDeviceIp())) {
+                                log.trace("Skipping UDP satellite device-name packet from interfaceIp={} to satelliteIp={} because route does not use this interface",
+                                        interfaceAddress.getAddress() != null ? interfaceAddress.getAddress().getHostAddress() : "unknown",
+                                        sat.getValue().getDeviceIp());
+                                continue;
+                            }
                             broadCastPing = getDatagramPacket(Constants.UDP_DEVICE_NAME_STATIC, sat.getValue().getDeviceIp(), InetAddress.getByName(sat.getValue().getDeviceIp()));
                             log.trace("Sending UDP satellite device-name packet from interfaceIp={} to satelliteIp={}",
                                     interfaceAddress.getAddress() != null ? interfaceAddress.getAddress().getHostAddress() : "unknown",
                                     sat.getValue().getDeviceIp());
-                            socket.send(broadCastPing);
+                            sendFromInterface(interfaceAddress, broadCastPing);
                         }
                     }
                 }
@@ -365,6 +413,10 @@ public class UdpServer {
         ScheduledExecutorService udpBrExecutorService = Executors.newScheduledThreadPool(1);
         Runnable pingTask = () -> {
             try {
+                if (!isSocketAvailable()) {
+                    udpBrExecutorService.shutdown();
+                    return;
+                }
                 DatagramPacket broadCastPing;
                 if (MainSingleton.getInstance().config.getSatellites() != null) {
                     boolean useBroadcast = !NetworkManager.isValidIp(MainSingleton.getInstance().config.getStaticGlowWormIp());
@@ -377,13 +429,19 @@ public class UdpServer {
                             interfaceAddress.getAddress() != null ? interfaceAddress.getAddress().getHostAddress() : "unknown",
                             broadCastPing.getAddress() != null ? broadCastPing.getAddress().getHostAddress() : "unknown",
                             useBroadcast ? "broadcast" : "static-ip");
-                    socket.send(broadCastPing);
+                    sendFromInterface(interfaceAddress, broadCastPing);
                     for (Map.Entry<String, Satellite> sat : MainSingleton.getInstance().config.getSatellites().entrySet()) {
+                        if (!isReachableViaInterface(interfaceAddress.getAddress(), sat.getValue().getDeviceIp())) {
+                            log.trace("Skipping UDP ping from interfaceIp={} to satelliteIp={} because route does not use this interface",
+                                    interfaceAddress.getAddress() != null ? interfaceAddress.getAddress().getHostAddress() : "unknown",
+                                    sat.getValue().getDeviceIp());
+                            continue;
+                        }
                         broadCastPing = getDatagramPacket(Constants.UDP_PING, interfaceAddress.getAddress().toString().substring(1), InetAddress.getByName(sat.getValue().getDeviceIp()));
                         log.trace("Sending UDP ping from interfaceIp={} to satelliteIp={}",
                                 interfaceAddress.getAddress() != null ? interfaceAddress.getAddress().getHostAddress() : "unknown",
                                 sat.getValue().getDeviceIp());
-                        socket.send(broadCastPing);
+                        sendFromInterface(interfaceAddress, broadCastPing);
                     }
                 }
             } catch (Exception e) {
@@ -436,6 +494,9 @@ public class UdpServer {
      */
     @SuppressWarnings("Duplicates")
     void shareBroadCastToOtherInstance(byte[] bufferBroadcastPing, int broadcastPort) {
+        if (!isSocketAvailable()) {
+            return;
+        }
         try {
             for (InterfaceAddress interfaceAddress : eligibleInterfaceAddresses) {
                 InetAddress broadcastAddress = interfaceAddress.getBroadcast();
@@ -447,7 +508,7 @@ public class UdpServer {
                 DatagramPacket broadCastPing = new DatagramPacket(bufferBroadcastPing, bufferBroadcastPing.length,
                         broadcastAddress, broadcastPort);
                 log.debug("Relaying UDP payload to broadcastIp={} port={}", broadcastAddress.getHostAddress(), broadcastPort);
-                socket.send(broadCastPing);
+                sendFromInterface(interfaceAddress, broadCastPing);
             }
         } catch (IOException e) {
             log.error(e.getMessage());

--- a/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
+++ b/src/main/java/org/dpsoftware/network/tcpUdp/UdpServer.java
@@ -317,7 +317,7 @@ public class UdpServer {
             testSocket.connect(new InetSocketAddress(targetIp, Constants.UDP_BROADCAST_PORT));
             InetAddress routedVia = testSocket.getLocalAddress();
             boolean match = routedVia != null && routedVia.equals(localAddress);
-            log.debug("Routing check localIp={} targetIp={} routedVia={} match={}",
+            log.trace("Routing check localIp={} targetIp={} routedVia={} match={}",
                     localAddress.getHostAddress(), targetIp,
                     routedVia != null ? routedVia.getHostAddress() : "null", match);
             return match;

--- a/src/main/java/org/dpsoftware/utilities/CommonUtility.java
+++ b/src/main/java/org/dpsoftware/utilities/CommonUtility.java
@@ -116,8 +116,12 @@ public class CommonUtility {
         // MQTT Stream
         if (MainSingleton.getInstance().config.isWirelessStream()) {
             if (!MainSingleton.getInstance().config.getOutputDevice().equals(Constants.SERIAL_PORT_AUTO) || MainSingleton.getInstance().config.getMultiMonitor() > 1) {
+                String outputDevice = MainSingleton.getInstance().config.getOutputDevice();
+                String staticGlowWormIp = MainSingleton.getInstance().config.getStaticGlowWormIp();
                 glowWormDeviceToUse = GuiSingleton.getInstance().deviceTableData.stream()
-                        .filter(glowWormDevice -> glowWormDevice.getDeviceName().equals(MainSingleton.getInstance().config.getOutputDevice()))
+                        .filter(glowWormDevice -> glowWormDevice.getDeviceName().equals(outputDevice)
+                                || glowWormDevice.getDeviceIP().equals(outputDevice)
+                                || (NetworkManager.isValidIp(staticGlowWormIp) && glowWormDevice.getDeviceIP().equals(staticGlowWormIp)))
                         .findAny().orElse(null);
             } else if (GuiSingleton.getInstance().deviceTableData != null && !GuiSingleton.getInstance().deviceTableData.isEmpty()) {
                 glowWormDeviceToUse = GuiSingleton.getInstance().deviceTableData.getFirst();

--- a/src/main/resources/build_assets/org.dpsoftware.FireflyLuciferin.appdata.xml
+++ b/src/main/resources/build_assets/org.dpsoftware.FireflyLuciferin.appdata.xml
@@ -74,70 +74,37 @@
         </screenshot>
     </screenshots>
     <releases>
-        <release version="2.27.6" date="2026-05-09">
-            <url type="details">https://github.com/sblantipodi/firefly_luciferin/releases/tag/v2.27.6</url>
+        <release version="2.28.4" date="2026-05-29">
+            <url type="details">https://github.com/sblantipodi/firefly_luciferin/releases/tag/v2.28.4</url>
             <description>
 
                 <p>Changes in this Release</p>
                 <ul>
-                    <li>Update requirement: requires <code>Glow Worm Luciferin</code> firmware (v5.24.9)
+                    <li>Update requirement: requires <code>Glow Worm Luciferin</code> firmware (v5.25.3)
                     </li>
-                    <li>The Luciferin Official PCB now supports the new Luciferin Module, compatible with smaller D1
-                        Mini format boards, allowing hardware upgrades without replacing the PCB or redoing any
-                        soldering or cabling. The Luciferin Ethernet Module adds Ethernet connectivity to boards that do
-                        not natively support it.
+                    <li>Enabled all LED configuration options for multi‑monitor setups.</li>
+                    <li>Due to recent Windows changes, installing or updating software now requires administrator
+                        privileges. Firefly Luciferin no longer needs to be launched in admin mode; it will request
+                        elevation only when required during the auto‑update process.
                     </li>
-                    <li>Added support for Espressif ESP32-C6 and ESP32-C5, enabling Wi-Fi 6 and 5 GHz band support on
-                        the C5. Closes #92.
+                    <li>Improved device discovery when using subnets/VLANs. Device discovery across different networks
+                        no longer relies solely on UDP unicast but now uses a TCP fallback, improving discoverability on
+                        certain routers.
                     </li>
-                    <li>Added support for SPI-based Ethernet devices; GPIO pins for custom SPI configurations can now be
-                        assigned directly from the Web Interface or the Provisioning section in Firefly Luciferin.
+                    <li>Fixed DSCP/Traffic Class handling for UDP sockets. Ensured correct IPv4 TOS byte encoding to
+                        maintain compatibility with recent Windows networking stack changes.
                     </li>
-                    <li>Added support for the Gledopto series with Ethernet.</li>
-                    <li>Luciferin is now available via the Windows Package Manager.</li>
-                    <li>The Web Installer has been updated to support newer devices. Firmware installation is now
-                        significantly easier on devices with a native USB interface (non-UART).
+                    <li>Fixed race conditions on UDP ports that occurred when using the multi‑monitor configuration with
+                        a single device.
                     </li>
-                    <li>Wi-Fi and Ethernet can now coexist and operate simultaneously. Firefly Luciferin automatically
-                        prioritizes the wired Ethernet connection when both are available.
+                    <li>Fixed an issue preventing firmware auto‑update on ESP32‑C3 devices.</li>
+                    <li>Fixed a crash occurring when enabling EMA smoothing technique.</li>
+                    <li>Fixed a crash that occurred when changing the configured LED count on the fly during UDP
+                        streaming while using a device with a Static IP.
                     </li>
-                    <li>Driving LEDs via USB is now considered stable on native USB devices (non-UART).</li>
-                    <li>USB provisioning via Firefly Luciferin now supports custom device naming, preventing name
-                        collisions when provisioning multiple devices simultaneously.
+                    <li>The tray icon tooltip did not display the device’s IP address when using multiple monitors.
+                        Fixed.
                     </li>
-                    <li>Users can now configure the GPIO pin of the built-in LED on their microcontroller, which
-                        provides visual feedback on the device's connection status.
-                    </li>
-                    <li>The Windows installation footprint has also been significantly reduced.</li>
-                    <li>Enhanced black bar detection with debounce logic to reduce false positives.</li>
-                    <li>Firmware upgraded to Arduino Core 3 (based on IDF5).</li>
-                    <li>Improved LED placement and alignment on the test canvas, with better spacing and resizing
-                        behavior when pressing Shift+Tab. Closes #406.
-                    </li>
-                    <li>Improved Glow Worm device discovery and UDP communication reliability on complex or
-                        multi-network setups, with refined interface selection, static IP fallback preservation,
-                        explicit stream socket binding to the correct subnet, and extended debug logging. Closes #400.
-                    </li>
-                    <li>Added a reminder for Linux users to add their account to the dialout or uucp group for USB
-                        device access. Closes #371.
-                    </li>
-                    <li>Improved visibility of option buttons on the Web Interface. Parts of the UI loading have been
-                        offloaded to the server side to reduce rendering overhead during heavy data streaming.
-                    </li>
-                    <li>Fixed a screen capture issue on KDE Plasma KWin 6.4 that occurred when using the Flatpak or Snap sandboxed version of Firefly Luciferin. </li>
-                    <li>Fixed GPIO0 being unable to drive the LED strip.</li>
-                    <li>Fixed baud rate changes not being applied when the device was under load.</li>
-                    <li>Fixed incorrect Wi-Fi signal strength readings when two or more MQTT devices were in use and one
-                        of them was connected via Ethernet.
-                    </li>
-                    <li>Fixed duplicate devices appearing in the Devices tab when using multiple devices
-                        simultaneously.
-                    </li>
-                    <li>Fixed the Web Interface not reporting the correct framerate when driving LEDs via USB.</li>
-                    <li>Fixed an issue that reset the LED GPIO to 0 when driving the LEDs over USB.</li>
-                    <li>Fixed an issue that prevented some Linux distributions from displaying the test image.</li>
-                    <li>Arduino Bootstrapper updated to v1.19.7.</li>
-                    <li>PlatformIO Version Increment updated to (v0.2.0).</li>
                 </ul>
 
                 <p>

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,4 +1,4 @@
 version=${project.version}
 minimum.firmware.version=5.24.9
 # This feature is not exposed to end users. Used for testing purpose only. Set false before the release.
-gw.alpha.download=false
+gw.alpha.download=true

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,4 +1,4 @@
 version=${project.version}
-minimum.firmware.version=5.24.9
+minimum.firmware.version=5.25.3
 # This feature is not exposed to end users. Used for testing purpose only. Set false before the release.
-gw.alpha.download=true
+gw.alpha.download=false


### PR DESCRIPTION
Changes in this Release

- ***Update Requirement:*** This release requires `Glow Worm Luciferin` firmware **v5.25.3**.
- **Enabled all LED configuration options for [multi‑monitor setups](https://github.com/sblantipodi/firefly_luciferin/wiki/Multi-monitor-support).** Closes [#417](https://github.com/sblantipodi/firefly_luciferin/issues/417).
- Due to recent Windows changes, [installing or updating software](https://github.com/sblantipodi/firefly_luciferin/wiki/Luciferin-update-management) now requires administrator privileges. Firefly Luciferin no longer needs to be launched in admin mode; it will request elevation only when required during the auto‑update process.
- Improved [device discovery](https://github.com/sblantipodi/firefly_luciferin/wiki/Static-IP-and-auto-discovery) when using subnets/VLANs. Device discovery across different networks no longer relies solely on UDP unicast but now uses a TCP fallback, improving discoverability on certain routers.
- Fixed DSCP/Traffic Class handling for UDP sockets. Ensured correct IPv4 TOS byte encoding to maintain compatibility with recent Windows networking stack changes. Closes [#419](https://github.com/sblantipodi/firefly_luciferin/issues/419).
- Fixed race conditions on UDP ports that occurred when using the multi‑monitor configuration with a single device.
- Fixed an issue preventing firmware auto‑update on ESP32‑C3 devices.
- Fixed a crash occurring when enabling [EMA smoothing technique](https://github.com/sblantipodi/firefly_luciferin/wiki/Smoothing-color-transitions). Closes [#416](https://github.com/sblantipodi/firefly_luciferin/issues/416).
- Fixed a crash that occurred when changing the configured LED count on the fly during UDP streaming while using a device with a Static IP.
- The tray icon tooltip did not display the device’s IP address when using multiple monitors. Fixed.
