### PR TITLE
Flatpak spawn

### DIFF
--- a/src/main/java/org/dpsoftware/NativeExecutor.java
+++ b/src/main/java/org/dpsoftware/NativeExecutor.java
@@ -104,6 +104,10 @@ public final class NativeExecutor {
         try {
             log.trace("Executing cmd={}", Arrays.stream(cmdToRunUsingArgs).toList());
             ProcessBuilder processBuilder = new ProcessBuilder(cmdToRunUsingArgs);
+            if (waitForOutput == 0) {
+                processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+                processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+            }
             Process process = processBuilder.start();
             if (waitForOutput > 0) {
                 if (process.waitFor(waitForOutput, TimeUnit.MILLISECONDS)) {
@@ -164,6 +168,12 @@ public final class NativeExecutor {
                 }
             }
             // We don't use NativeExecutor.exit() here because we need to avoid race conditions
+            log.info("Waiting for 20 Seconds so we see the output of the spawned instances before exiting");
+            try {
+                Thread.sleep(20000);
+            } catch (InterruptedException e) {
+                log.error("Interrupted while waiting for 20 Seconds", e);
+            }
             System.exit(0);
         }
     }

--- a/src/main/java/org/dpsoftware/NativeExecutor.java
+++ b/src/main/java/org/dpsoftware/NativeExecutor.java
@@ -168,12 +168,6 @@ public final class NativeExecutor {
                 }
             }
             // We don't use NativeExecutor.exit() here because we need to avoid race conditions
-            log.info("Waiting for 20 Seconds so we see the output of the spawned instances before exiting");
-            try {
-                Thread.sleep(20000);
-            } catch (InterruptedException e) {
-                log.error("Interrupted while waiting for 20 Seconds", e);
-            }
             System.exit(0);
         }
     }

--- a/src/main/java/org/dpsoftware/NativeExecutor.java
+++ b/src/main/java/org/dpsoftware/NativeExecutor.java
@@ -104,10 +104,6 @@ public final class NativeExecutor {
         try {
             log.trace("Executing cmd={}", Arrays.stream(cmdToRunUsingArgs).toList());
             ProcessBuilder processBuilder = new ProcessBuilder(cmdToRunUsingArgs);
-            if (waitForOutput == 0) {
-                processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
-                processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-            }
             Process process = processBuilder.start();
             if (waitForOutput > 0) {
                 if (process.waitFor(waitForOutput, TimeUnit.MILLISECONDS)) {

--- a/src/main/java/org/dpsoftware/config/Constants.java
+++ b/src/main/java/org/dpsoftware/config/Constants.java
@@ -807,7 +807,7 @@ public class Constants {
     public static final String RESTART_DELAY = "RESTART_DELAY";
     public static final int RESTART_DELAY_SECONDS = 3;
     public static final int RESTART_TIMEOUT = -180;
-    public static final String[] FLATPAK_RUN = {"flatpak-spawn", "FireflyLuciferin"};
+    public static final String[] FLATPAK_RUN = {"flatpak-spawn", "/app/bin/FireflyLuciferin"};
     public static final String[] SNAP_RUN = {"FireflyLuciferin"};
     public static final String FLATPAK_ID = "FLATPAK_ID";
     public static final String SNAP_NAME = "SNAP_NAME";


### PR DESCRIPTION
Try to fix #421

With this changes (only Constants.java is necessary), is launches the two instances without problem.
processBuilder.redirect helped me find the error: execve didnt see FireflyLuciferin, so give it the absolute path.

But i am doing something wrong at compiling, because now i get this from the 2 instances:
```
Exception in thread "main" java.lang.RuntimeException: Exception in Application start method
	at com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:899)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication$0(LauncherImpl.java:202)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NoClassDefFoundError: jdk/incubator/vector/IntVector
	at org.dpsoftware.NativeExecutor.setSimdAvxInstructions(NativeExecutor.java:495)
	at org.dpsoftware.FireflyLuciferin.start(FireflyLuciferin.java:314)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$4(LauncherImpl.java:845)
	at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$0(PlatformImpl.java:449)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$0(PlatformImpl.java:424)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$0(GtkApplication.java:242)
	... 1 more
Caused by: java.lang.ClassNotFoundException: jdk.incubator.vector.IntVector
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	... 9 more
Exception in thread "main" java.lang.RuntimeException: Exception in Application start method
	at com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:899)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication$0(LauncherImpl.java:202)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NoClassDefFoundError: jdk/incubator/vector/IntVector
	at org.dpsoftware.NativeExecutor.setSimdAvxInstructions(NativeExecutor.java:495)
	at org.dpsoftware.FireflyLuciferin.start(FireflyLuciferin.java:314)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$4(LauncherImpl.java:845)
	at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$0(PlatformImpl.java:449)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$0(PlatformImpl.java:424)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$0(GtkApplication.java:242)
	... 1 more
Caused by: java.lang.ClassNotFoundException: jdk.incubator.vector.IntVector
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
```